### PR TITLE
txtp bao etc

### DIFF
--- a/cli/txtp_maker.py
+++ b/cli/txtp_maker.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+
+# ########################################################################### #
+# TXTP MAKER
+# ########################################################################### #
+
+from __future__ import division
+import subprocess
+import zlib
+import os.path
+import os
+import re
+import sys
+import fnmatch
+
+def print_usage(appname):
+    print("Usage: {} (filename) [options]".format(appname)+"\n"
+          "\n"
+          "Creates (filename)_(subsong).txtp for every subsong in (filename).\n"
+          " (filename) can be a * or *.ext wildcard too (works with dupe filters).\n"
+          "Works with files with no subsongs (unless filtered) too.\n"
+          "\n"
+          "Use -h to print [options]. Examples:\n"
+          "\n"
+          "{} bgm.fsb -in -fcm 2 -fms 5.0 ".format(appname)+"\n"
+          "    make TXTP for subsongs with at least 2 channels and 5 seconds\n"
+          "{} *.scd -r -fd -l 2".format(appname)+"\n"
+          "   all .scd in subdirs, ignoring dupes and making per 2ch layers\n"
+          "{} *.sm1 -fne .+STREAM[.]SS[0-9]$ ".format(appname)+"\n"
+          "    all .sm1 excluding those subsong names that ends with 'STREAM.SS0..9'\n"
+          "{} samples.bnk -fni ^bgm.? ".format(appname)+"\n"
+          "    in .bnk including only subsong names that start with 'bgm'\n"
+          "{} * -r -fss 1".format(appname)+"\n"
+          "   all files in subdirs with at least 1 subsong (ignoring formats without them)\n"
+          )
+
+def print_help(appname):
+    print("Options:\n"
+          " -r: find recursive (writes files to current dir, with dir in TXTP)\n"
+          " -c (name): set path to CLI (default: test.exe)\n"
+          " -n (name): use (name)_(subsong).txtp format\n"
+          "   You can put '{filename}' somewhere to get it substituted by the base name\n"
+          " -z N: zero-fill subsong number (default: auto fill up to total subsongs)\n"
+          " -d (dir): add dir in TXTP (if the file will reside in a subdir)\n"
+          " -m: create mini-txtp\n"
+          " -o: overwrite existing .txtp (beware when using with internal names)\n"
+          " -in: name TXTP using the subsong's internal name if found\n"
+          " -ie: remove internal name's extension\n"
+          " -ii: add subsong number when using internal name\n"
+          " -l N: create multiple TXTP per subsong layers, every N channels\n"
+          " -fd: filter duplicates (slower)\n"
+          " -fcm N: filter min channels\n"
+          " -fcM N: filter by max channels\n"
+          " -frm N: filter by min sample rate\n"
+          " -frM N: filter by max sample rate\n"
+          " -fsm N.N: filter by min seconds\n"
+          " -fsM N.N: filter by max seconds\n"
+          " -fss N: filter min subsongs (1 filters formats incapable of subsongs)\n"
+          " -fni (regex): filter by subsong name, include files that match\n"
+          " -fne (regex): filter by subsong name, exclude files that match\n"
+          " -v (name): verbose level (off|trace|debug|info, default: info)\n"
+          " -h N: show this help\n"
+          )
+
+# ########################################################################### #
+
+def find_files(dir, pattern, recursive):
+    files = []
+    for root, dirnames, filenames in os.walk(dir):
+        for filename in fnmatch.filter(filenames, pattern):
+            files.append(os.path.join(root, filename))
+
+        if not recursive:
+            break
+            
+    return files
+
+def make_cmd(cfg, fname_in, fname_out, target_subsong):
+    if (cfg.test_dupes):
+        cmd = "{} -s {} -i -o {} {}".format(cfg.cli, target_subsong, fname_out, fname_in)
+    else:
+        cmd = "{} -s {} -m -i -o {} {}".format(cfg.cli, target_subsong, fname_out, fname_in)
+    return cmd
+
+class LogHelper(object):
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def trace(self, msg):
+        v = self.cfg.verbose
+        if v == "trace":
+            print(msg)
+
+    def debug(self, msg):
+        v = self.cfg.verbose
+        if v == "trace" or v == "debug":
+            print(msg)
+
+    def info(self, msg):
+        v = self.cfg.verbose
+        if v == "trace" or v == "debug" or v == "info":
+            print(msg)
+
+class ConfigHelper(object):
+    show_help = False
+    cli = "test.exe"
+
+    recursive = False
+    base_name = ''
+    zero_fill = -1
+    subdir = ''
+    mini_txtp = False
+    overwrite = False
+    layers = 0
+
+    use_internal_name = False
+    use_internal_ext = False
+    use_internal_index = False
+
+    test_dupes = False
+    min_channels = 0
+    max_channels = 0
+    min_sample_rate = 0
+    max_sample_rate = 0
+    min_seconds = 0.0
+    max_seconds = 0.0
+    min_subsongs = 0
+    include_regex = ""
+    exclude_regex = ""
+
+    verbose = "info"
+
+    argv_len = 0
+    index = 0
+
+
+    def read_bool(self, command, default):
+        if self.index > self.argv_len - 1:
+            return default
+        if self.argv[self.index] == command:
+            val = True
+            self.index += 1
+            return val
+        return default
+    
+    def read_value(self, command, default):
+        if self.index > self.argv_len - 2:
+            return default
+        if self.argv[self.index] == command:
+            val = self.argv[self.index+1]
+            self.index += 2
+            return val
+        return default
+
+    def read_string(self, command, default):
+        return str(self.read_value(command, default))
+
+    def read_int(self, command, default):
+        return int(self.read_value(command, default))
+
+    def read_float(self, command, default):
+        return float(self.read_value(command, default))
+
+    #todo improve this poop
+    def __init__(self, argv):
+        self.index = 2 #after file
+        self.argv = argv 
+        self.argv_len = len(argv)
+
+        if argv[1] == '-h':
+            self.show_help = True
+        
+        prev_index = self.index
+        while self.index < len(self.argv):
+            self.show_help = self.read_bool('-h', self.show_help)
+            self.cli = self.read_string('-c', self.cli)
+            self.recursive = self.read_bool('-r', self.recursive)
+            self.base_name = self.read_string('-n', self.base_name)
+            self.zero_fill = self.read_int('-z', self.zero_fill)
+            self.subdir = self.read_string('-d', self.subdir)
+
+            self.test_dupes = self.read_bool('-fd', self.test_dupes)
+            self.min_channels = self.read_int('-fcm', self.min_channels)
+            self.max_channels = self.read_int('-fcM', self.max_channels)
+            self.min_sample_rate = self.read_int('-frm', self.min_sample_rate)
+            self.max_sample_rate = self.read_int('-frM', self.max_sample_rate)
+            self.min_seconds = self.read_float('-fsm', self.min_seconds)
+            self.max_seconds = self.read_float('-fsM', self.max_seconds)
+            self.min_subsongs = self.read_int('-fss', self.min_subsongs)
+            self.include_regex = self.read_string('-fni', self.include_regex)
+            self.exclude_regex = self.read_string('-fne', self.exclude_regex)
+
+            self.mini_txtp = self.read_bool('-m', self.mini_txtp)
+            self.overwrite = self.read_bool('-o', self.overwrite)
+            self.layers = self.read_int('-l', self.layers)
+
+            self.use_internal_name = self.read_bool('-in', self.use_internal_name)
+            self.use_internal_ext = self.read_bool('-ie', self.use_internal_ext)
+            self.use_internal_index = self.read_bool('-ii', self.use_internal_index)
+
+            self.verbose = self.read_string('-v', self.verbose)
+
+            if prev_index == self.index:
+                self.index += 1
+            prev_index = self.index
+
+        if (self.subdir != '') and not (self.subdir.endswith('/') or self.subdir.endswith('\\')):
+            self.subdir += '/'
+
+    def __str__(self):
+        return str(self.__dict__)
+
+
+class Cr32Helper(object):
+    crc32_map = {}
+    dupe = False
+    cfg = None
+    
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def get_crc32(self, fname):
+        buf_size = 0x8000
+        with open(fname, 'rb') as file:
+            buf = file.read(buf_size)
+            crc32 = 0
+            while len(buf) > 0:
+                crc32 = zlib.crc32(buf, crc32)
+                buf = file.read(buf_size)
+        return crc32 & 0xFFFFFFFF 
+
+    def update(self, fname):
+        cfg = self.cfg
+
+        self.dupe = False
+        if cfg.test_dupes == 0:
+            return
+        if not os.path.exists(fname):
+            return
+
+        crc32_str = format(self.get_crc32(fname),'08x')
+        if (crc32_str in self.crc32_map):
+            self.dupe = True
+            return
+        self.crc32_map[crc32_str] = True
+
+        return
+
+    def is_dupe(self):
+        return self.dupe
+
+
+class TxtpMaker(object):
+    channels = 0
+    sample_rate = 0
+    num_samples = 0
+    stream_count = 0
+    stream_index = 0
+    stream_name = ''
+    stream_seconds = 0
+
+    def __init__(self, cfg, output_b, log):
+        self.cfg = cfg
+        self.log = log
+
+        self.output = str(output_b).replace("\\r","").replace("\\n","\n")
+        self.channels = self.get_value("channels: ")
+        self.sample_rate = self.get_value("sample rate: ")
+        self.num_samples = self.get_value("stream total samples: ")
+        self.stream_count = self.get_value("stream count: ")
+        self.stream_index = self.get_value("stream index: ")
+        self.stream_name = self.get_string("stream name: ")
+
+        if self.channels == 0:
+            raise ValueError('Incorrect command result')
+
+        self.stream_seconds = self.num_samples / self.sample_rate
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def get_string(self, str):
+        find_pos = self.output.find(str)
+        if (find_pos == -1):
+            return ''
+        cut_pos = find_pos + len(str)
+        str_cut = self.output[cut_pos:]
+        return str_cut.split()[0]
+
+    def get_value(self, str):
+        res = self.get_string(str)
+        if (res == ''):
+           return 0;
+        return int(res)
+
+    def is_ignorable(self):
+        cfg = self.cfg
+
+        if (self.channels < cfg.min_channels):
+            return True;
+        if (cfg.max_channels > 0 and self.channels > cfg.max_channels):
+            return True;
+        if (self.sample_rate < cfg.min_sample_rate):
+            return True;
+        if (cfg.max_sample_rate > 0 and self.sample_rate > cfg.max_sample_rate):
+            return True;
+        if (self.stream_seconds < cfg.min_seconds):
+            return True;
+        if (cfg.max_seconds > 0 and self.stream_seconds > cfg.max_seconds):
+            return True;
+        if (self.stream_count < cfg.min_subsongs):
+            return True;
+        if (cfg.exclude_regex != "" and self.stream_name != ""):
+            p = re.compile(cfg.exclude_regex)
+            if (p.match(self.stream_name) != None):
+                return True
+        if (cfg.include_regex != "" and self.stream_name != ""):
+            p = re.compile(cfg.include_regex)
+            if (p.match(self.stream_name) == None):
+                return True
+
+        return False
+
+    def get_stream_mask(self, layer):
+        cfg = self.cfg
+
+        mask = '#c'
+
+        loops = cfg.layers
+        if layer + cfg.layers > self.channels:
+            loops = self.channels - cfg.layers
+        for ch in range(0,loops):
+            mask += str(layer+ch) + ','
+
+        mask = mask[:-1]
+        return mask
+
+    def get_stream_name(self):
+        cfg = self.cfg
+
+        if not cfg.use_internal_name:
+            return ''
+        txt = self.stream_name
+
+        # remove paths #todo maybe config/replace?
+        pos = txt.rfind("\\")
+        if (pos != -1):
+            txt = txt[pos+1:]
+        pos = txt.rfind("/")
+        if (pos != -1):
+            txt = txt[pos+1:]
+        # remove bad chars
+        txt = txt.replace("%", "_")
+        txt = txt.replace("*", "_")
+        txt = txt.replace("?", "_")
+        txt = txt.replace(":", "_")
+        txt = txt.replace("\"", "_")
+        txt = txt.replace("|", "_")
+        txt = txt.replace("<", "_")
+        txt = txt.replace(">", "_")
+    
+        if not cfg.use_internal_ext:
+            pos = txt.rfind(".")
+            if (pos != -1):
+                txt = txt[:pos]
+        return txt
+        
+    def write(self, outname, line):
+        cfg = self.cfg
+
+        outname += '.txtp'
+        if not cfg.overwrite and os.path.exists(outname):
+            raise ValueError('TXTP exists in path: ' + outname)
+        ftxtp = open(outname,"w+")
+        if line != '':
+            ftxtp.write(line)
+        ftxtp.close()
+
+        self.log.debug("created: " + outname)
+        return
+
+    def make(self, fname_path, fname_clean):
+        cfg = self.cfg
+        total_done = 0
+
+        if self.is_ignorable():
+            return total_done
+
+        # write plain (name).txtp when no subsongs
+        if self.stream_count <= 1:
+            index = ""
+        else:
+            index = str(self.stream_index)
+            if cfg.zero_fill < 0:
+                index = index.zfill(len(str(self.stream_count)))
+            else:
+                index = index.zfill(cfg.zero_fill)
+
+        if cfg.mini_txtp:
+            outname = fname_path
+            if index != "":
+                outname += "#" + index
+
+            if cfg.layers > 0 and cfg.layers < self.channels:
+                for layer in range(0, self.channels, cfg.layers):
+                    mask = self.get_stream_mask(layer)
+                    self.write(outname + mask, '')
+                    total_done += 1
+            else:
+                self.write(outname, '')
+                total_done += 1
+
+        else:
+            stream_name = self.get_stream_name()
+            if stream_name != '':
+                outname = stream_name
+                if cfg.use_internal_index:
+                    outname += "_{}".format(index)
+            else:
+                if cfg.base_name != '':
+                    fname_base = os.path.basename(fname_path)
+                    pos = fname_base.rfind(".") #remove ext
+                    if (pos != -1 and pos > 1):
+                        fname_base = fname_base[:pos]
+                
+                    txt = cfg.base_name
+                    txt = txt.replace("{filename}",fname_base)
+                    
+                else:
+                    txt = fname_path
+                    pos = txt.rfind(".") #remove ext
+                    if (pos != -1 and pos > 1):
+                        txt = txt[:pos]
+                outname = "{}".format(txt)
+                if index != "":
+                    outname += "_" + index
+
+            line = ''
+            if cfg.subdir != '':
+                line += cfg.subdir
+            line += fname_clean
+            if index != "":
+                line += "#" + index
+
+            if cfg.layers > 0 and cfg.layers < self.channels:
+                done = 0
+                for layer in range(0, self.channels, cfg.layers):
+                    sub = chr(ord('a') + done)
+                    done += 1
+                    mask = self.get_stream_mask(layer)
+                    self.write(outname + sub, line + mask)
+                    total_done += 1
+            else:
+                self.write(outname, line)
+                total_done += 1
+        return total_done
+
+    def has_more_subsongs(self, target_subsong):
+        return target_subsong < self.stream_count
+
+# ########################################################################### #
+
+def main():
+    appname = os.path.basename(sys.argv[0])
+    if (len(sys.argv) <= 1):
+        print_usage(appname)
+        return
+
+    cfg = ConfigHelper(sys.argv)
+    crc32 = Cr32Helper(cfg)
+    log = LogHelper(cfg)
+
+    if cfg.show_help:
+        print_help(appname)
+        return
+
+    fname = sys.argv[1]
+    fnames_in = find_files('.', fname, cfg.recursive)
+
+    total_created = 0
+    total_dupes = 0
+    total_errors = 0
+    for fname_in in fnames_in:
+        fname_in_clean = fname_in.replace("\\", "/")
+        if fname_in_clean.startswith("./"):
+            fname_in_clean = fname_in_clean[2:]
+           
+        fname_in_base = os.path.basename(fname_in)
+        
+        if fname_in.startswith(".\\"): #skip starting dot for extensionless files
+            fname_in = fname_in[2:]
+        
+        fname_out = ".temp." + fname_in_base + ".wav"
+        created = 0
+        dupes = 0
+        errors = 0
+        target_subsong = 1
+        while 1:
+
+            try:
+                cmd = make_cmd(cfg, fname_in, fname_out, target_subsong)
+                log.trace("calling: " + cmd)
+                output_b = subprocess.check_output(cmd, shell=False) #stderr=subprocess.STDOUT
+            except subprocess.CalledProcessError as e:
+                log.debug("ignoring CLI error in " + fname_in + "#"+str(target_subsong)+": " + e.output)
+                errors += 1
+                break
+
+            if target_subsong == 1:
+                log.debug("processing {}...".format(fname_in_clean))
+
+            maker = TxtpMaker(cfg, output_b, log)
+
+            if not maker.is_ignorable():
+                crc32.update(fname_out)
+
+            if not crc32.is_dupe():
+                created += maker.make(fname_in_base, fname_in_clean)
+            else:
+                dupes += 1
+                log.debug("Dupe subsong {}".format(target_subsong))
+
+            if not maker.has_more_subsongs(target_subsong):
+                break
+            target_subsong += 1
+
+            if target_subsong % 200 == 0:
+                log.info("{}/{} subsongs... ".format(target_subsong, maker.stream_count) + 
+                          "({} dupes, {} errors)".format(dupes, errors)
+                          )
+
+        if os.path.exists(fname_out):
+            os.remove(fname_out)
+
+        total_created += created
+        total_dupes += dupes
+        total_errors += errors
+
+
+    log.info("done! ({} done, {} dupes, {} errors)".format(total_created, total_dupes, total_errors))
+    
+if __name__ == "__main__":
+    main()

--- a/cli/vgmstream_cli.c
+++ b/cli/vgmstream_cli.c
@@ -468,11 +468,11 @@ int main(int argc, char ** argv) {
     /* slap on a .wav header */
     {
         uint8_t wav_buf[0x100];
-        int channels = (cfg.only_stereo != -1) ? 2 : channels;
+        int channels_write = (cfg.only_stereo != -1) ? 2 : channels;
         size_t bytes_done;
 
         bytes_done = make_wav_header(wav_buf,0x100,
-                len_samples, vgmstream->sample_rate, channels,
+                len_samples, vgmstream->sample_rate, channels_write,
                 cfg.write_lwav, cfg.lwav_loop_start, cfg.lwav_loop_end);
 
         fwrite(wav_buf,sizeof(uint8_t),bytes_done,outfile);
@@ -541,11 +541,11 @@ int main(int argc, char ** argv) {
         /* slap on a .wav header */
         {
             uint8_t wav_buf[0x100];
-            int channels = (cfg.only_stereo != -1) ? 2 : channels;
+            int channels_write = (cfg.only_stereo != -1) ? 2 : channels;
             size_t bytes_done;
 
             bytes_done = make_wav_header(wav_buf,0x100,
-                    len_samples, vgmstream->sample_rate, channels,
+                    len_samples, vgmstream->sample_rate, channels_write,
                     cfg.write_lwav, cfg.lwav_loop_start, cfg.lwav_loop_end);
 
             fwrite(wav_buf,sizeof(uint8_t),bytes_done,outfile);

--- a/cli/vgmstream_cli.c
+++ b/cli/vgmstream_cli.c
@@ -216,6 +216,7 @@ fail:
 }
 
 static void print_info(VGMSTREAM * vgmstream, cli_config *cfg) {
+    int channels = vgmstream->channels;
     if (!cfg->play_sdtout) {
         if (cfg->print_adxencd) {
             printf("adxencd");
@@ -236,7 +237,7 @@ static void print_info(VGMSTREAM * vgmstream, cli_config *cfg) {
         else if (cfg->print_batchvar) {
             if (!cfg->print_metaonly)
                 printf("set fname=\"%s\"\n",cfg->outfilename);
-            printf("set tsamp=%d\nset chan=%d\n", vgmstream->num_samples, vgmstream->channels);
+            printf("set tsamp=%d\nset chan=%d\n", vgmstream->num_samples, channels);
             if (vgmstream->loop_flag)
                 printf("set lstart=%d\nset lend=%d\nset loop=1\n", vgmstream->loop_start_sample, vgmstream->loop_end_sample);
             else
@@ -312,16 +313,18 @@ static void apply_config(VGMSTREAM * vgmstream, cli_config *cfg) {
     }
 }
 
-void apply_fade(sample * buf, VGMSTREAM * vgmstream, int to_get, int i, int len_samples, int fade_samples) {
-    if (vgmstream->loop_flag && fade_samples > 0) {
+void apply_fade(sample * buf, VGMSTREAM * vgmstream, int to_get, int i, int len_samples, int fade_samples, int channels) {
+    int is_fade_on = vgmstream->loop_flag;
+
+    if (is_fade_on && fade_samples > 0) {
         int samples_into_fade = i - (len_samples - fade_samples);
         if (samples_into_fade + to_get > 0) {
             int j, k;
             for (j = 0; j < to_get; j++, samples_into_fade++) {
                 if (samples_into_fade > 0) {
                     double fadedness = (double)(fade_samples - samples_into_fade) / fade_samples;
-                    for (k = 0; k < vgmstream->channels; k++) {
-                        buf[j*vgmstream->channels+k] = (sample)buf[j*vgmstream->channels+k]*fadedness;
+                    for (k = 0; k < channels; k++) {
+                        buf[j*channels + k] = (sample)buf[j*channels + k] * fadedness;
                     }
                 }
             }
@@ -337,6 +340,7 @@ int main(int argc, char ** argv) {
     char outfilename_temp[PATH_LIMIT];
 
     sample * buf = NULL;
+    int channels;
     int32_t len_samples;
     int32_t fade_samples;
     int i, j;
@@ -453,16 +457,18 @@ int main(int argc, char ** argv) {
 
 
     /* last init */
-    buf = malloc(BUFFER_SAMPLES*sizeof(sample)*vgmstream->channels);
+    channels = vgmstream->channels;
+
+    buf = malloc(BUFFER_SAMPLES * sizeof(sample) * channels);
     if (!buf) {
         fprintf(stderr,"failed allocating output buffer\n");
-        goto fail;;
+        goto fail;
     }
 
     /* slap on a .wav header */
     {
         uint8_t wav_buf[0x100];
-        int channels = (cfg.only_stereo != -1) ? 2 : vgmstream->channels;
+        int channels = (cfg.only_stereo != -1) ? 2 : channels;
         size_t bytes_done;
 
         bytes_done = make_wav_header(wav_buf,0x100,
@@ -477,15 +483,15 @@ int main(int argc, char ** argv) {
     while (cfg.play_forever) {
         int to_get = BUFFER_SAMPLES;
 
-        render_vgmstream(buf,to_get,vgmstream);
+        render_vgmstream(buf, to_get, vgmstream);
 
-        swap_samples_le(buf,vgmstream->channels*to_get); /* write PC endian */
+        swap_samples_le(buf, channels * to_get); /* write PC endian */
         if (cfg.only_stereo != -1) {
             for (j = 0; j < to_get; j++) {
-                fwrite(buf+j*vgmstream->channels+(cfg.only_stereo*2),sizeof(sample),2,outfile);
+                fwrite(buf + j*channels + (cfg.only_stereo*2), sizeof(sample), 2, outfile);
             }
         } else {
-            fwrite(buf,sizeof(sample)*vgmstream->channels,to_get,outfile);
+            fwrite(buf, sizeof(sample) * channels, to_get, outfile);
         }
     }
 
@@ -496,17 +502,17 @@ int main(int argc, char ** argv) {
         if (i + BUFFER_SAMPLES > len_samples)
             to_get = len_samples - i;
 
-        render_vgmstream(buf,to_get,vgmstream);
+        render_vgmstream(buf, to_get, vgmstream);
 
-        apply_fade(buf, vgmstream, to_get, i, len_samples, fade_samples);
+        apply_fade(buf, vgmstream, to_get, i, len_samples, fade_samples, channels);
 
-        swap_samples_le(buf,vgmstream->channels*to_get); /* write PC endian */
+        swap_samples_le(buf, channels * to_get); /* write PC endian */
         if (cfg.only_stereo != -1) {
             for (j = 0; j < to_get; j++) {
-                fwrite(buf+j*vgmstream->channels+(cfg.only_stereo*2),sizeof(sample),2,outfile);
+                fwrite(buf + j*channels + (cfg.only_stereo*2), sizeof(sample), 2, outfile);
             }
         } else {
-            fwrite(buf,sizeof(sample)*vgmstream->channels,to_get,outfile);
+            fwrite(buf, sizeof(sample) * channels, to_get, outfile);
         }
     }
 
@@ -535,7 +541,7 @@ int main(int argc, char ** argv) {
         /* slap on a .wav header */
         {
             uint8_t wav_buf[0x100];
-            int channels = (cfg.only_stereo != -1) ? 2 : vgmstream->channels;
+            int channels = (cfg.only_stereo != -1) ? 2 : channels;
             size_t bytes_done;
 
             bytes_done = make_wav_header(wav_buf,0x100,
@@ -551,17 +557,17 @@ int main(int argc, char ** argv) {
             if (i + BUFFER_SAMPLES > len_samples)
                 to_get = len_samples - i;
 
-            render_vgmstream(buf,to_get,vgmstream);
+            render_vgmstream(buf, to_get, vgmstream);
 
-            apply_fade(buf, vgmstream, to_get, i, len_samples, fade_samples);
+            apply_fade(buf, vgmstream, to_get, i, len_samples, fade_samples, channels);
 
-            swap_samples_le(buf,vgmstream->channels*to_get); /* write PC endian */
+            swap_samples_le(buf, channels * to_get); /* write PC endian */
             if (cfg.only_stereo != -1) {
                 for (j = 0; j < to_get; j++) {
-                    fwrite(buf+j*vgmstream->channels+(cfg.only_stereo*2),sizeof(sample),2,outfile);
+                    fwrite(buf + j*channels + (cfg.only_stereo*2), sizeof(sample), 2, outfile);
                 }
             } else {
-                fwrite(buf,sizeof(sample)*vgmstream->channels,to_get,outfile);
+                fwrite(buf, sizeof(sample) * channels, to_get, outfile);
             }
         }
         fclose(outfile);
@@ -574,14 +580,12 @@ int main(int argc, char ** argv) {
     return EXIT_SUCCESS;
 
 fail:
-    if (!cfg.play_sdtout)
-    {
+    if (!cfg.play_sdtout) {
         if (outfile != NULL)
-        {
             fclose(outfile);
-        }
     }
     close_vgmstream(vgmstream);
+    free(buf);
     return EXIT_FAILURE;
 }
 

--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -5,29 +5,73 @@ TXTP is a text file with commands, to improve support for games using audio in c
 Simply create a file named `(filename).txtp`, and inside write the commands described below.
 
 
-## TXTP features
+## TXTP FEATURES
 
 ### Play separate intro + loop files together as a single track
-- __Ratchet & Clank (PS2)__: _bgm01.txtp_
+Some games clumsily loop audio by using multiple full file "segments":
+ 
+__Ratchet & Clank (PS2)__: _bgm01.txtp_
 ```
-# define several files to play as one (there is no limit) 
+# define 2 or more segments to play as one
 BGM01_BEGIN.VAG
 BGM01_LOOPED.VAG
 
-# multi-files must define loops
+# segments must define loops
 loop_start_segment = 2 # 2nd file start
 loop_end_segment = 2 # optional, default is last
+```
+Channel number must be equal, mixing sample rates is ok (uses first).
 
-#channel number must be equal, mixing sample rates is ok (uses first)
+If your loop segment has proper loops you want to keep, you can use:
+```
+BGM_SUMMON_0001_01-Intro.hca
+BGM_SUMMON_0001_01-Intro2.hca
+BGM_SUMMON_0001_01.hca
+
+loop_start_segment = 3
+loop_mode = keep  # loops in 3rd file's loop_start to 3rd file's loop_end
+```
+```
+bgm_intro.adx
+bgm_main.adx
+bgm_main2.adx
+
+loop_start_segment = 2
+loop_end_segment = 3
+loop_mode = keep    # loops in 2nd file's loop_start to 3rd file's loop_end
 ```
 
+### Multilayered songs
+TXTP "layers" play songs with channels/parts divided into files as one (for example main melody + vocal track).
+
+__Nier Automata__: _BGM_0_012_song2.txtp_
+```
+# mix dynamic sections (2ch * 2)
+BGM_0_012_04.wem
+BGM_0_012_07.wem
+
+mode = layers
+```
+
+__Life is Strange__: _BIK_E1_6A_DialEnd.txtp_
+```
+# bik multichannel isn't autodetectable so must mix manually (1ch * 3)
+BIK_E1_6A_DialEnd_00000000.audio.multi.bik#1
+BIK_E1_6A_DialEnd_00000000.audio.multi.bik#2
+BIK_E1_6A_DialEnd_00000000.audio.multi.bik#3
+
+mode = layers
+```
+Note that the number of channels is the sum of all layers, so three 2ch layers play as a 6ch file.
+
+
 ### Minifiles for bank formats without splitters
-- __Super Robot Taisen OG Saga - Masou Kishin III - Pride of Justice (Vita)__: _bgm_12.txtp_
+__Super Robot Taisen OG Saga - Masou Kishin III - Pride of Justice (Vita)__: _bgm_12.txtp_
 ```
 # select subsong 12
 bigfiles/bgm.sxd2#12 #relative paths are ok too for TXTP
 
-#bigfiles/bgm.sxd2#s12 # "sN" is al alt for subsong
+#bigfiles/bgm.sxd2#s12 # "sN" is alt for subsong
 
 # single files loop normally by default
 # if loop segment is defined it forces a full loop (0..num_samples)
@@ -35,7 +79,7 @@ bigfiles/bgm.sxd2#12 #relative paths are ok too for TXTP
 ```
 
 ### Play segmented subsongs as one
-- __Prince of Persia Sands of Time__: _song_01.txtp_
+__Prince of Persia Sands of Time__: _song_01.txtp_
 ```
 # can use ranges ~ to avoid so much C&P
 amb_fx.sb0#254
@@ -48,13 +92,13 @@ loop_start_segment = 3
 
 
 ### Channel mask for channel subsongs/layers
-- __Final Fantasy XIII-2__: _music_Home_01.ps3.txtp_
+__Final Fantasy XIII-2__: _music_Home_01.ps3.txtp_
 ```
 #plays channels 1 and 2 = 1st subsong
 music_Home.ps3.scd#c1,2
 ```
 
-- __Final Fantasy XIII-2__: _music_Home_02.ps3.txtp_
+__Final Fantasy XIII-2__: _music_Home_02.ps3.txtp_
 ```
 #plays channels 3 and 4 = 2nd subsong
 music_Home.ps3.scd#c3,4
@@ -63,48 +107,10 @@ music_Home.ps3.scd#c3,4
 ```
 
 
-### Multilayered songs
-
-TXTP "layers" play songs with channels/parts divided into files as one.
-
-- __Nier Automata__: _BGM_0_012_song2.txtp_
-```
-# mix dynamic sections (2ch * 2)
-BGM_0_012_04.wem
-BGM_0_012_07.wem
-
-mode = layers
-```
-
-- __Life is Strange__: _BIK_E1_6A_DialEnd.txtp_
-```
-# bik multichannel isn't autodetectable so must mix manually (1ch * 3)
-BIK_E1_6A_DialEnd_00000000.audio.multi.bik#1
-BIK_E1_6A_DialEnd_00000000.audio.multi.bik#2
-BIK_E1_6A_DialEnd_00000000.audio.multi.bik#3
-
-mode = layers
-```
-Note that the number of channels is the sum of all layers, so three 2ch layers play as a 6ch file.
-
-
-
-### Channel swapping/mapping
-TXTP can swap channels for custom channel mappings. It does "swapping" rather than simpler "mapping" since vgmstream can't read a format's mappings or guess which channel is which. Format is:
-```
-#ch1 = first
-file1.ext#m2-3  # "FL BL FR BR" to "FL FR BL BR"
-
-#do note the order specified affects swapping
-file2.ext#m2-3,4-5,4-6  # ogg "FL CN FR BL BR SB" to wav "FL FR CN SB BL BR"
-```
-Note that channel masking applies after mappings.
-
-
 ### Custom play settings
 Those setting should override player's defaults if set (except "loop forever"). They are equivalent to some test.exe options.
 
-- __God Hand (PS2)__: _boss2_3ningumi_ver6.txtp_ (each line is a separate TXTP)
+__God Hand (PS2)__: _boss2_3ningumi_ver6.txtp_ (each line is a separate TXTP)
 ```
 # set number of loops
 boss2_3ningumi_ver6.adx#l3
@@ -134,6 +140,19 @@ boss2_3ningumi_ver6.adx#l1.5#d1#f5
 ```
 
 For segments and layers the first file defines looping options.
+
+
+### Force sample rate
+A few games set a sample rate value in the header but actually play with other (applying some of pitch or just forcing it)
+
+__Super Paper Mario (Wii)__
+```
+btl_koopa1_44k_lp.brstm#h22050  #in hz
+```
+__Patapon (PSP)__
+```
+ptp_btl_bgm_voice.sgd#s1#h11050
+```
 
 
 ### Force plugin extensions
@@ -175,7 +194,7 @@ commands = #s12
 ```
 
 
-## TXTP parsing issues
+## TXTP PARSING ISSUES
 *Commands* can be chained, but must not be separated by a space (everything after space may be ignored):
 ```
 bgm bank.sxd2#s12#c1,2  #spaces + comment after commands is ignored
@@ -193,34 +212,14 @@ loop_start_segment   =    1  #spaces surrounding value are ignored
 ```
 ```
 bgm.sxd2
-config =  #s12#c1,2   #must not have spaces once value starts until end
+commands =  #s12#c1,2   #must not have spaces once value starts until end
 ```
 The parser is very simplistic and fairly lax, though may be erratic with edge cases or behave unexpectedly due to unforeseen use-cases and bugs. As filenames may contain spaces or #, certain name patterns could fool it too. Keep in mind this while making .txtp files.
 
 
-## Mini TXTP
-
+## MINI-TXTP
 To simplify TXTP creation, if the .txtp is empty (0 bytes) its filename is used directly as a command. Note that extension is also included (since vgmstream needs a full filename).
 - _bgm.sxd2#12.txtp_: plays subsong 12
 - _Ryoshima Coast 1 & 2.aix#c1,2.txtp_: channel mask
 - _boss2_3ningumi_ver6.adx#l2#F.txtp_: loop twice then play song end file normally
 - etc
-
-
-## Other examples
-
-_Join "segments" (intro+body):_
-```
-#files must have same number of channels
-Song001_intro.ogg
-Song001_body.ogg
-loop_start_segment = 2
-```
-
-_Join "layers" (ex. main+vocals):_
-```
-#files must have same number of samples
-Song001_main.ogg
-Song001_vocals.ogg
-mode = layers
-```

--- a/fb2k/foo_vgmstream.cpp
+++ b/fb2k/foo_vgmstream.cpp
@@ -131,11 +131,11 @@ void input_vgmstream::get_info(t_uint32 p_subsong, file_info & p_info, abort_cal
     int length_in_ms=0, channels = 0, samplerate = 0;
     int total_samples = -1;
     int bitrate = 0;
-    int loop_start = -1, loop_end = -1;
+    int loop_flag = -1, loop_start = -1, loop_end = -1;
     pfc::string8 description;
     pfc::string8_fast temp;
 
-    get_subsong_info(p_subsong, temp, &length_in_ms, &total_samples, &loop_start, &loop_end, &samplerate, &channels, &bitrate, description, p_abort);
+    get_subsong_info(p_subsong, temp, &length_in_ms, &total_samples, &loop_flag, &loop_start, &loop_end, &samplerate, &channels, &bitrate, description, p_abort);
 
 
     /* set tag info (metadata tab in file properties) */
@@ -193,7 +193,8 @@ void input_vgmstream::get_info(t_uint32 p_subsong, file_info & p_info, abort_cal
     p_info.info_set_bitrate(bitrate / 1000);
     if (total_samples > 0)
         p_info.info_set_int("stream_total_samples", total_samples);
-    if (loop_start >= 0 && loop_end >= loop_start) {
+    if (loop_start >= 0 && loop_end > loop_start) {
+        p_info.info_set("looping", loop_flag > 0 ? "enabled" : "disabled");
         p_info.info_set_int("loop_start", loop_start);
         p_info.info_set_int("loop_end", loop_end);
     }
@@ -440,7 +441,7 @@ void input_vgmstream::setup_vgmstream(abort_callback & p_abort) {
     fade_samples = (int)(config.song_fade_time * vgmstream->sample_rate);
 }
 
-void input_vgmstream::get_subsong_info(t_uint32 p_subsong, pfc::string_base & title, int *length_in_ms, int *total_samples, int *loop_start, int *loop_end, int *sample_rate, int *channels, int *bitrate, pfc::string_base & description, abort_callback & p_abort) {
+void input_vgmstream::get_subsong_info(t_uint32 p_subsong, pfc::string_base & title, int *length_in_ms, int *total_samples, int *loop_flag, int *loop_start, int *loop_end, int *sample_rate, int *channels, int *bitrate, pfc::string_base & description, abort_callback & p_abort) {
     VGMSTREAM * infostream = NULL;
     bool is_infostream = false;
     foobar_song_config infoconfig;
@@ -473,10 +474,9 @@ void input_vgmstream::get_subsong_info(t_uint32 p_subsong, pfc::string_base & ti
             *channels = infostream->channels;
             *total_samples = infostream->num_samples;
             *bitrate = get_vgmstream_average_bitrate(infostream);
-            if (infostream->loop_flag) {
-                *loop_start = infostream->loop_start_sample;
-                *loop_end = infostream->loop_end_sample;
-            }
+            *loop_flag = infostream->loop_flag;
+            *loop_start = infostream->loop_start_sample;
+            *loop_end = infostream->loop_end_sample;
 
             char temp[1024];
             describe_vgmstream(infostream, temp, 1024);

--- a/fb2k/foo_vgmstream.h
+++ b/fb2k/foo_vgmstream.h
@@ -85,7 +85,7 @@ class input_vgmstream : public input_stubs {
         VGMSTREAM * init_vgmstream_foo(t_uint32 p_subsong, const char * const filename, abort_callback & p_abort);
         void setup_vgmstream(abort_callback & p_abort);
         void load_settings();
-        void get_subsong_info(t_uint32 p_subsong, pfc::string_base & title, int *length_in_ms, int *total_samples, int *loop_start, int *loop_end, int *sample_rate, int *channels, int *bitrate, pfc::string_base & description, abort_callback & p_abort);
+        void get_subsong_info(t_uint32 p_subsong, pfc::string_base & title, int *length_in_ms, int *total_samples, int *loop_flag, int *loop_start, int *loop_end, int *sample_rate, int *channels, int *bitrate, pfc::string_base & description, abort_callback & p_abort);
         bool get_description_tag(pfc::string_base & temp, pfc::string_base const& description, const char *tag, char delimiter = '\n');
         void set_config_defaults(foobar_song_config *current);
         void apply_config(VGMSTREAM * vgmstream, foobar_song_config *current);

--- a/src/formats.c
+++ b/src/formats.c
@@ -123,6 +123,7 @@ static const char* extension_list[] = {
     "de2",
     "dec",
     "dmsg",
+    "ds2", //txth/reserved [Star Wars Bounty Hunter (GC)]
     "dsf",
     "dsp",
     "dspw",

--- a/src/formats.c
+++ b/src/formats.c
@@ -1171,6 +1171,7 @@ static const meta_info meta_info_list[] = {
         {meta_GIN,                  "Electronic Arts Gnsu header"},
         {meta_DSF,                  "Ocean DSF header"},
         {meta_208,                  "Ocean .208 header"},
+        {meta_DSP_DS2,              "LucasArts .DS2 header"},
 
 };
 

--- a/src/layout/layered.c
+++ b/src/layout/layered.c
@@ -96,11 +96,9 @@ int setup_layout_layered(layered_layout_data* data) {
             }
         }
 
-        //todo could check if layers'd loop match vs main, etc
+        /* loops and other values could be mismatched but hopefully not */
 
-        /* save start things so we can restart for seeking/looping */
-        memcpy(data->layers[i]->start_ch,data->layers[i]->ch,sizeof(VGMSTREAMCHANNEL)*data->layers[i]->channels);
-        memcpy(data->layers[i]->start_vgmstream,data->layers[i],sizeof(VGMSTREAM));
+        setup_vgmstream(data->layers[i]); /* final setup in case the VGMSTREAM was created manually */
     }
 
     return 1;

--- a/src/layout/segmented.c
+++ b/src/layout/segmented.c
@@ -24,8 +24,8 @@ void render_vgmstream_segmented(sample * buffer, int32_t sample_count, VGMSTREAM
             while (total_samples < vgmstream->num_samples) {
                 int32_t segment_samples = data->segments[loop_segment]->num_samples;
 
-                if (vgmstream->loop_start_sample >= total_samples && vgmstream->loop_start_sample < total_samples + segment_samples) {
-                    loop_samples_skip = vgmstream->loop_start_sample - total_samples;
+                if (vgmstream->loop_sample >= total_samples && vgmstream->loop_sample < total_samples + segment_samples) {
+                    loop_samples_skip = vgmstream->loop_sample - total_samples;
                     break; /* loop_start falls within loop_segment's samples */
                 }
                 total_samples += segment_samples;
@@ -134,9 +134,7 @@ int setup_layout_segmented(segmented_layout_data* data) {
         }
 
 
-        /* save start things so we can restart for seeking/looping */
-        memcpy(data->segments[i]->start_ch,data->segments[i]->ch,sizeof(VGMSTREAMCHANNEL)*data->segments[i]->channels);
-        memcpy(data->segments[i]->start_vgmstream,data->segments[i],sizeof(VGMSTREAM));
+        setup_vgmstream(data->segments[i]); /* final setup in case the VGMSTREAM was created manually */
     }
 
 

--- a/src/layout/segmented.c
+++ b/src/layout/segmented.c
@@ -6,7 +6,7 @@
  * Chains together sequential vgmstreams, for data divided into separate sections or files
  * (like one part for intro and other for loop segments, which may even use different codecs). */
 void render_vgmstream_segmented(sample * buffer, int32_t sample_count, VGMSTREAM * vgmstream) {
-    int samples_written = 0;
+    int samples_written = 0, loop_samples_skip = 0;
     segmented_layout_data *data = vgmstream->layout_data;
 
 
@@ -16,28 +16,34 @@ void render_vgmstream_segmented(sample * buffer, int32_t sample_count, VGMSTREAM
 
 
         if (vgmstream->loop_flag && vgmstream_do_loop(vgmstream)) {
-            /* handle looping, finding loop segment */
-            int loop_segment = 0, samples = 0, loop_samples_skip = 0;
-            while (samples < vgmstream->num_samples) {
+            int segment, loop_segment, total_samples;
+
+            /* handle looping by finding loop segment and loop_start inside that segment */
+            loop_segment = 0;
+            total_samples = 0;
+            while (total_samples < vgmstream->num_samples) {
                 int32_t segment_samples = data->segments[loop_segment]->num_samples;
-                if (vgmstream->loop_start_sample >= samples && vgmstream->loop_start_sample < samples + segment_samples) {
-                    loop_samples_skip = vgmstream->loop_start_sample - samples;
+
+                if (vgmstream->loop_start_sample >= total_samples && vgmstream->loop_start_sample < total_samples + segment_samples) {
+                    loop_samples_skip = vgmstream->loop_start_sample - total_samples;
                     break; /* loop_start falls within loop_segment's samples */
                 }
-                samples += segment_samples;
+                total_samples += segment_samples;
                 loop_segment++;
             }
+
             if (loop_segment == data->segment_count) {
                 VGM_LOG("segmented_layout: can't find loop segment\n");
                 loop_segment = 0;
             }
-            if (loop_samples_skip > 0) {
-                VGM_LOG("segmented_layout: loop starts after %i samples\n", loop_samples_skip);
-                //todo skip/fix, but probably won't happen
-            }
 
             data->current_segment = loop_segment;
-            reset_vgmstream(data->segments[data->current_segment]);
+
+            /* loops can span multiple segments */
+            for (segment = loop_segment; segment < data->segment_count; segment++) {
+                reset_vgmstream(data->segments[segment]);
+            }
+
             vgmstream->samples_into_block = 0;
             continue;
         }
@@ -45,6 +51,12 @@ void render_vgmstream_segmented(sample * buffer, int32_t sample_count, VGMSTREAM
         samples_to_do = vgmstream_samples_to_do(samples_this_block, sample_count, vgmstream);
         if (samples_to_do > sample_count - samples_written)
             samples_to_do = sample_count - samples_written;
+
+        /* segment looping: discard until actual start */
+        if (loop_samples_skip > 0) {
+            if (samples_to_do > loop_samples_skip)
+                samples_to_do = loop_samples_skip;
+        }
 
         /* detect segment change and restart */
         if (samples_to_do == 0) {
@@ -57,9 +69,15 @@ void render_vgmstream_segmented(sample * buffer, int32_t sample_count, VGMSTREAM
         render_vgmstream(&buffer[samples_written*data->segments[data->current_segment]->channels],
                 samples_to_do,data->segments[data->current_segment]);
 
-        samples_written += samples_to_do;
-        vgmstream->current_sample += samples_to_do;
-        vgmstream->samples_into_block += samples_to_do;
+        if (loop_samples_skip > 0) {
+            loop_samples_skip -= samples_to_do;
+            vgmstream->samples_into_block += samples_to_do;
+        }
+        else {
+            samples_written += samples_to_do;
+            vgmstream->current_sample += samples_to_do;
+            vgmstream->samples_into_block += samples_to_do;
+        }
     }
 }
 

--- a/src/meta/aix.c
+++ b/src/meta/aix.c
@@ -136,8 +136,8 @@ VGMSTREAM * init_vgmstream_aix(STREAMFILE *streamFile) {
             /* setup layers */
             if (temp_vgmstream->num_samples != data->sample_counts[i] || temp_vgmstream->loop_flag != 0)
                 goto fail;
-            memcpy(temp_vgmstream->start_ch,temp_vgmstream->ch,sizeof(VGMSTREAMCHANNEL)*temp_vgmstream->channels);
-            memcpy(temp_vgmstream->start_vgmstream,temp_vgmstream,sizeof(VGMSTREAM));
+
+            setup_vgmstream(temp_vgmstream); /* final setup as the VGMSTREAM was created manually */
         }
     }
 

--- a/src/meta/bnk_sony.c
+++ b/src/meta/bnk_sony.c
@@ -176,8 +176,15 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
                     case 0xC2: sample_rate = 44100; break;
                     case 0xBC: sample_rate = 36000; break; //?
                     case 0xBA: sample_rate = 32000; break; //?
+                    case 0xB9: sample_rate = 30000; break; //?
+                    case 0xB8: sample_rate = 28000; break; //?
                     case 0xB6: sample_rate = 22050; break;
+                    case 0xB0: sample_rate = 15000; break; //?
+                    case 0xAF: sample_rate = 14000; break; //?
+                    case 0xAE: sample_rate = 13000; break; //?
+                    case 0xAC: sample_rate = 12000; break; //?
                     case 0xAA: sample_rate = 11025; break;
+                    case 0xA9: sample_rate = 10000; break; //?
                     default:
                         VGM_LOG("BNK: unknown pitch %x\n", pitch);
                         goto fail;

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -49,6 +49,7 @@ VGMSTREAM * init_vgmstream_dsp_switch_audio(STREAMFILE *streamFile);
 VGMSTREAM * init_vgmstream_dsp_sps_n1(STREAMFILE *streamFile);
 VGMSTREAM * init_vgmstream_dsp_itl_ch(STREAMFILE *streamFile);
 VGMSTREAM * init_vgmstream_dsp_adpcmx(STREAMFILE *streamFile);
+VGMSTREAM * init_vgmstream_dsp_ds2(STREAMFILE *streamFile);
 
 VGMSTREAM * init_vgmstream_csmp(STREAMFILE *streamFile);
 

--- a/src/meta/ngc_dsp_std.c
+++ b/src/meta/ngc_dsp_std.c
@@ -223,7 +223,7 @@ static VGMSTREAM * init_vgmstream_dsp_common(STREAMFILE *streamFile, dsp_meta *d
     if (dspm->fix_looping && vgmstream->loop_end_sample > vgmstream->num_samples)
         vgmstream->loop_end_sample = vgmstream->num_samples;
 
-    if (dspm->single_header) {
+    if (dspm->single_header == 2) { /* double the samples */
         vgmstream->num_samples /= dspm->channel_count;
         vgmstream->loop_start_sample /= dspm->channel_count;
         vgmstream->loop_end_sample /= dspm->channel_count;
@@ -517,14 +517,13 @@ VGMSTREAM * init_vgmstream_ngc_mpdsp(STREAMFILE *streamFile) {
     if (!check_extensions(streamFile, "mpdsp"))
         goto fail;
 
-    /* at 0x48 is extra data that could help differenciating these DSPs, but other games
-     * put similar stuff there, needs more checks (ex. Battallion Wars, Army Men) */
-    //0x00005300 60A94000 64FF1200 00000000 00000000 00000000
+    /* at 0x48 is extra data that could help differenciating these DSPs, but seems like
+     * memory garbage created by the encoder that other games also have */
     /* 0x02(2): sample rate, 0x08+: channel sizes/loop offsets? */
 
     dspm.channel_count = 2;
     dspm.max_channels = 2;
-    dspm.single_header = 1;
+    dspm.single_header = 2;
 
     dspm.header_offset =  0x00;
     dspm.header_spacing = 0x00; /* same header for both channels */
@@ -1204,7 +1203,7 @@ VGMSTREAM * init_vgmstream_dsp_ds2(STREAMFILE *streamFile) {
 
     /* checks */
     /* .ds2: real extension, dsp: fake/renamed */
-    if (!check_extensions(streamFile, "ds2"))
+    if (!check_extensions(streamFile, "ds2,dsp"))
         goto fail;
     if (!(read_32bitBE(0x50,streamFile) == 0 &&
           read_32bitBE(0x54,streamFile) == 0 &&
@@ -1213,8 +1212,7 @@ VGMSTREAM * init_vgmstream_dsp_ds2(STREAMFILE *streamFile) {
         goto fail;
     file_size = get_streamfile_size(streamFile);
     channel_offset = read_32bitBE(0x5c,streamFile);  /* absolute offset to 2nd channel */
-    /* just to make sure */
-    if (channel_offset < file_size / 2 || channel_offset > file_size)
+    if (channel_offset < file_size / 2 || channel_offset > file_size) /* just to make sure */
         goto fail;
 
     dspm.channel_count = 2;

--- a/src/meta/ubi_bao.c
+++ b/src/meta/ubi_bao.c
@@ -203,12 +203,12 @@ VGMSTREAM * init_vgmstream_ubi_bao_spk(STREAMFILE *streamFile) {
     /* Variation of .pk:
      * - 0x00: 0x014B5053 ("SPK\01" LE)
      * - 0x04: BAO count
-     * - 0x08 * count: BAO ids inside
+     * - 0x08: BAO ids inside (0x04 * BAO count)
      * - per BAO count
-     *   - 0x00: 1?
-     *   - 0x04: id that references this? (ex. id of an event BAO)
-     *   - 0x08: BAO size
-     *   - 0x0c+: BAO data
+     *   - 0x00: table count
+     *   - 0x04: ids related to this BAO? (0x04 * table count)
+     *   - 0x08/NN: BAO size
+     *   - 0x0c/NN+: BAO data up to size
      *
      * BAOs reference .sbao by name (are considered atomic) so perhaps could
      * be considered a type of bigfile.
@@ -690,12 +690,12 @@ static VGMSTREAM * init_vgmstream_ubi_bao_header(ubi_bao_header * bao, STREAMFIL
         goto fail; /* not uncommon */
     }
 
-    ;VGM_LOG("UBI BAO: target at %x, h_id=%08x, s_id=%08x, p_id=%08x\n",
-        (uint32_t)bao->header_offset, bao->header_id, bao->stream_id, bao->prefetch_id);
-    ;VGM_LOG("UBI BAO: stream=%x, size=%x, res=%s\n",
-            (uint32_t)bao->stream_offset, bao->stream_size, (bao->is_external ? bao->resource_name : "internal"));
-    ;VGM_LOG("UBI BAO: type=%i, header=%x, extra=%x, prefetch=%x, size=%x\n",
-            bao->header_type, bao->header_size, bao->extra_size, (uint32_t)bao->prefetch_offset, bao->prefetch_size);
+    //;VGM_LOG("UBI BAO: target at %x, h_id=%08x, s_id=%08x, p_id=%08x\n",
+    //    (uint32_t)bao->header_offset, bao->header_id, bao->stream_id, bao->prefetch_id);
+    //;VGM_LOG("UBI BAO: stream=%x, size=%x, res=%s\n",
+    //        (uint32_t)bao->stream_offset, bao->stream_size, (bao->is_external ? bao->resource_name : "internal"));
+    //;VGM_LOG("UBI BAO: type=%i, header=%x, extra=%x, prefetch=%x, size=%x\n",
+    //        bao->header_type, bao->header_size, bao->extra_size, (uint32_t)bao->prefetch_offset, bao->prefetch_size);
 
 
     switch(bao->type) {
@@ -800,8 +800,8 @@ static int parse_pk(ubi_bao_header * bao, STREAMFILE *streamFile) {
         bao_offset += bao_size; /* files simply concat BAOs */
     }
 
-    ;VGM_LOG("UBI BAO: class "); {int i; for (i=0;i<16;i++){ VGM_ASSERT(bao->classes[i],"%02x=%i ",i,bao->classes[i]); }} VGM_LOG("\n");
-    ;VGM_LOG("UBI BAO: types "); {int i; for (i=0;i<16;i++){ VGM_ASSERT(bao->types[i],"%02x=%i ",i,bao->types[i]); }} VGM_LOG("\n");
+    //;VGM_LOG("UBI BAO: class "); {int i; for (i=0;i<16;i++){ VGM_ASSERT(bao->classes[i],"%02x=%i ",i,bao->classes[i]); }} VGM_LOG("\n");
+    //;VGM_LOG("UBI BAO: types "); {int i; for (i=0;i<16;i++){ VGM_ASSERT(bao->types[i],"%02x=%i ",i,bao->types[i]); }} VGM_LOG("\n");
 
     close_streamfile(streamIndex);
     close_streamfile(streamTest);
@@ -1821,6 +1821,7 @@ static int config_bao_version(ubi_bao_header * bao, STREAMFILE *streamFile) {
             /* same as 0x001B0100 except:
              * - base 0xA0, skip 0x24, name style %08x.bao (not .sbao?) */
         case 0x001D0A00: /* Shaun White Snowboarding (PSP)-atomic-opal */
+        case 0x00220017: /* Avatar (PS3)-atomic/spk */
         case 0x00220018: /* Avatar (PS3)-atomic/spk */
         case 0x00260102: /* Prince of Persia Trilogy HD (PS3)-package-gear */
             /* similar to 0x00250108 but most values are moved +4

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -61,7 +61,7 @@
 typedef struct _STREAMFILE {
     size_t (*read)(struct _STREAMFILE *,uint8_t * dest, off_t offset, size_t length);
     size_t (*get_size)(struct _STREAMFILE *);
-    off_t (*get_offset)(struct _STREAMFILE *);    
+    off_t (*get_offset)(struct _STREAMFILE *);   //todo: DO NOT USE, NOT RESET PROPERLY (remove?)
     /* for dual-file support */
     void (*get_name)(struct _STREAMFILE *,char *name,size_t length);
     struct _STREAMFILE * (*open)(struct _STREAMFILE *,const char * const filename,size_t buffersize);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -526,6 +526,13 @@ static VGMSTREAM * init_vgmstream_internal(STREAMFILE *streamFile) {
             try_dual_file_stereo(vgmstream, streamFile, init_vgmstream_functions[i]);
         }
 
+        /* clean as loops are readable metadata but loop fields may contain garbage
+         * (done *after* dual stereo as it needs loop fields to match) */
+        if (!vgmstream->loop_flag) {
+            vgmstream->loop_start_sample = 0;
+            vgmstream->loop_end_sample = 0;
+        }
+
 #ifdef VGM_USE_FFMPEG
         /* check FFmpeg streams here, for lack of a better place */
         if (vgmstream->coding_type == coding_FFmpeg) {

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -465,6 +465,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_gin,
     init_vgmstream_dsf,
     init_vgmstream_208,
+    init_vgmstream_dsp_ds2,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -746,6 +746,11 @@ VGMSTREAM * allocate_vgmstream(int channel_count, int loop_flag) {
     vgmstream->channels = channel_count;
     vgmstream->loop_flag = loop_flag;
 
+#ifdef VGMSTREAM_MIXING
+    /* fixed arrays, for now */
+    vgmstream->mixing_size = 64;
+    vgmstream->stream_name_size = STREAM_NAME_SIZE;
+#endif
     return vgmstream;
 fail:
     if (vgmstream) {
@@ -2274,9 +2279,12 @@ void describe_vgmstream(VGMSTREAM * vgmstream, char * desc, int length) {
     }
 
     snprintf(temp,TEMPSIZE,
-            "sample rate: %d Hz\n"
+            "sample rate: %d Hz\n",
+            vgmstream->sample_rate);
+    concatn(length,desc,temp);
+
+    snprintf(temp,TEMPSIZE,
             "channels: %d\n",
-            vgmstream->sample_rate,
             vgmstream->channels);
     concatn(length,desc,temp);
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -5,8 +5,9 @@
 #ifndef _VGMSTREAM_H
 #define _VGMSTREAM_H
 
+ /* reasonable maxs */
 enum { PATH_LIMIT = 32768 };
-enum { STREAM_NAME_SIZE = 255 }; /* reasonable max */
+enum { STREAM_NAME_SIZE = 255 };
 
 #include "streamfile.h"
 
@@ -720,6 +721,29 @@ typedef enum {
 
 } meta_t;
 
+#ifdef VGMSTREAM_MIXING
+/* mixing info */
+typedef enum {
+    MIX_SWAP,
+    MIX_ADD,
+    MIX_ADD_VOLUME,
+    MIX_VOLUME,
+    MIX_CROSSFADE,
+    MIX_DOWNMIX,
+    MIX_DOWNMIX_REST,
+    MIX_UPMIX
+} mix_command_t;
+
+typedef struct {
+    mix_command_t command;
+    int ch_a;
+    int ch_b;
+    float vol_a;
+    float vol_b;
+    float pos_a;
+    float pos_b;
+} mix_config_data;
+#endif
 
 /* info for a single vgmstream channel */
 typedef struct {
@@ -799,6 +823,13 @@ typedef struct {
     uint32_t channel_mask;          /* to silence crossfading subsongs/layers */
     int channel_mappings_on;        /* channel mappings are active */
     int channel_mappings[32];       /* swap channel "i" with "[i]" */
+#ifdef VGMSTREAM_MIXING
+    int output_channels;            /* resulting channels after mixing (may be ignored if plugin doesn't support it) */
+    int mixing_on;                  /* mixing allowed */
+    int mixing_count;               /* mixing number */
+    mix_config_data mixing[64];     /* applies transformation to output samples (could be alloc'ed but to simplify...) */
+    size_t mixing_size;             /* mixing max */
+#endif
     /* config requests, players must read and honor these values */
     /* (ideally internally would work as a player, but for now player must do it manually) */
     double config_loop_count;

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -718,6 +718,7 @@ typedef enum {
     meta_GIN,
     meta_DSF,
     meta_208,
+    meta_DSP_DS2,
 
 } meta_t;
 


### PR DESCRIPTION
- Fix some .baf [James Bond 007: Blood Stone (X360)]
- Add TXTP "loop_mode=keep" for intro+main songs that also loop normally
- Fix some more BAOs
- Fix memory corruption when forcing loops and clean internals
- Show loop info even when disabling loops in plugin's config
- Fix mpeg state not properly resetting in some cases
- Add TXTP "#h(rate)" to force sample rate
- Fix some .bnk [Manhunt 2 (PSP)]
- Add txtp_maker.py companion CLI tool
- Add .ds2 [Star Wars Bounty Hunter (GC)]

