### PR TITLE
txtp akb at3

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ in foobar's preferences):
   
 If your player isn't picking tags make sure vgmstream is detecting the song
 (as other plugins can steal its extensions, see above), .m3u is properly
-named and that filenames inside match the song filename.
+named and that filenames inside match the song filename. For Winamp you need
+to make sure options > titles > advanced title formatting checkbox is set and
+the format defined.
 
 
 ## Supported codec types

--- a/cli/txtp_maker.py
+++ b/cli/txtp_maker.py
@@ -38,8 +38,9 @@ def print_help(appname):
     print("Options:\n"
           " -r: find recursive (writes files to current dir, with dir in TXTP)\n"
           " -c (name): set path to CLI (default: test.exe)\n"
-          " -n (name): use (name)_(subsong).txtp format\n"
-          "   You can put '{filename}' somewhere to get it substituted by the base name\n"
+          " -n (name): use (name).txtp, that can be formatted using:\n"
+          "   {filename}, {subsong}, {internal-name}\n"
+          "   ex. -n BGM_{subsong}, -n {subsong}__{internal-name} "
           " -z N: zero-fill subsong number (default: auto fill up to total subsongs)\n"
           " -d (dir): add dir in TXTP (if the file will reside in a subdir)\n"
           " -m: create mini-txtp\n"
@@ -436,18 +437,25 @@ class TxtpMaker(object):
                     pos = fname_base.rfind(".") #remove ext
                     if (pos != -1 and pos > 1):
                         fname_base = fname_base[:pos]
+                        
+                    internal_name = self.stream_name
                 
                     txt = cfg.base_name
                     txt = txt.replace("{filename}",fname_base)
-                    
+                    txt = txt.replace("{subsong}",index)
+                    txt = txt.replace("{internal-name}",internal_name)
+
+                    outname = "{}".format(txt)
+
                 else:
                     txt = fname_path
                     pos = txt.rfind(".") #remove ext
                     if (pos != -1 and pos > 1):
                         txt = txt[:pos]
-                outname = "{}".format(txt)
-                if index != "":
-                    outname += "_" + index
+
+                    outname = "{}".format(txt)
+                    if index != "":
+                        outname += "_" + index
 
             line = ''
             if cfg.subdir != '':

--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -134,6 +134,12 @@ music_Home.ps3.scd#c1~3
 ```
 Doesn't change the final number of channels though, just mutes non-selected channels.
 
+If you use **`C(number)`** it will remove non-selected channels (not done directly for backwards compatibility). This just a shortcut for macro `#@track` (described later):
+```
+#plays channels 3 and 4 = 2nd subsong and removes other channels
+music_Home.ps3.scd#C3 4
+```
+
 
 ### Custom play settings
 **`#l(loops)`**, **`#f(fade)`**, **`#d(fade-delay)`**, **`#i(ignore loop)`**, **`#F(ignore fade)`**, **`#E(end-to-end loop)`**

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -291,6 +291,7 @@ void free_ffmpeg(ffmpeg_codec_data *data);
 
 void ffmpeg_set_skip_samples(ffmpeg_codec_data * data, int skip_samples);
 uint32_t ffmpeg_get_channel_layout(ffmpeg_codec_data * data);
+void ffmpeg_set_channel_remapping(ffmpeg_codec_data * data, int *channels_remap);
 
 /* ffmpeg_decoder_custom_opus.c (helper-things) */
 ffmpeg_codec_data * init_ffmpeg_switch_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);

--- a/src/layout/layered.c
+++ b/src/layout/layered.c
@@ -50,7 +50,9 @@ void render_vgmstream_layered(sample_t * outbuf, int32_t sample_count, VGMSTREAM
         }
 
         samples_written += samples_to_do;
-        vgmstream->current_sample = data->layers[0]->current_sample; /* just in case it's used for info */
+        /* needed for info (ex. for mixing) */
+        vgmstream->current_sample = data->layers[0]->current_sample;
+        vgmstream->loop_count = data->layers[0]->loop_count;
         //vgmstream->samples_into_block = 0; /* handled in each layer */
     }
 }

--- a/src/meta/akb.c
+++ b/src/meta/akb.c
@@ -192,7 +192,7 @@ VGMSTREAM * init_vgmstream_akb2(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     off_t start_offset, material_offset, extradata_offset;
     size_t material_size, extradata_size, stream_size;
-    int loop_flag = 0, channel_count, encryption_flag, codec, sample_rate, /*num_samples,*/ loop_start, loop_end;
+    int loop_flag = 0, channel_count, encryption_flag, codec, sample_rate, num_samples, loop_start, loop_end;
     int total_subsongs, target_subsong = streamFile->stream_index;
 
     /* check extensions */
@@ -237,7 +237,7 @@ VGMSTREAM * init_vgmstream_akb2(STREAMFILE *streamFile) {
     material_size   = read_16bitLE(material_offset+0x04,streamFile);
     sample_rate     = (uint16_t)read_16bitLE(material_offset+0x06,streamFile);
     stream_size     = read_32bitLE(material_offset+0x08,streamFile);
-  //num_samples     = read_32bitLE(material_offset+0x0c,streamFile);
+    num_samples     = read_32bitLE(material_offset+0x0c,streamFile);
 
     loop_start      = read_32bitLE(material_offset+0x10,streamFile);
     loop_end        = read_32bitLE(material_offset+0x14,streamFile);
@@ -263,6 +263,17 @@ VGMSTREAM * init_vgmstream_akb2(STREAMFILE *streamFile) {
     vgmstream->meta_type = meta_AKB;
 
     switch (codec) {
+        case 0x01: /* PCM16LE [Mobius: Final Fantasy (Android)] */
+            vgmstream->coding_type = coding_PCM16LE;
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = 0x02;
+
+            vgmstream->num_samples       = num_samples;
+            vgmstream->loop_start_sample = loop_start;
+            vgmstream->loop_end_sample   = loop_end;
+            break;
+
+
         case 0x02: { /* MSADPCM [The Irregular at Magic High School Lost Zero (Android)] */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
@@ -323,7 +334,6 @@ VGMSTREAM * init_vgmstream_akb2(STREAMFILE *streamFile) {
         }
 #endif
 
-        case 0x01: /* PCM16LE */
         default:
             goto fail;
     }

--- a/src/meta/txtp.c
+++ b/src/meta/txtp.c
@@ -285,7 +285,7 @@ static void apply_config(VGMSTREAM *vgmstream, txtp_entry *current) {
         for (ch = 0; ch < vgmstream->channels; ch++) {
             if (!((current->channel_mask >> ch) & 1)) {
                 txtp_mix_data mix = {0};
-                mix.ch_dst = ch;
+                mix.ch_dst = ch + 1;
                 mix.vol = 0.0f;
                 add_mixing(current, &mix, MIX_VOLUME);
             }
@@ -880,7 +880,8 @@ static int add_filename(txtp_header * txtp, char *filename, int is_default) {
 
                 add_mixing(&cfg, &mix, MACRO_VOLUME);
             }
-            else if (strcmp(command,"@track") == 0) {
+            else if (strcmp(command,"@track") == 0 ||
+                     strcmp(command,"C") == 0 ) {
                 txtp_mix_data mix = {0};
 
                 nm = get_mask(config, &mix.mask);
@@ -930,7 +931,9 @@ static int add_filename(txtp_header * txtp, char *filename, int is_default) {
             }
             else {
                 //;VGM_LOG("TXTP:   unknown command\n");
-                break; /* end, incorrect command, or possibly a comment or double ## comment too */
+                /* end, incorrect command, or possibly a comment or double ## comment too
+                 * (shouldn't fail for forward compatibility) */
+                break;
             }
         }
     }

--- a/src/mixing.c
+++ b/src/mixing.c
@@ -468,6 +468,7 @@ void mixing_push_add(VGMSTREAM* vgmstream, int ch_dst, int ch_src, double volume
     mix.ch_src = ch_src;
     mix.vol = volume;
 
+    //;VGM_LOG("MIX: add %i+%i*%f\n", ch_dst,ch_src,volume);
     add_mixing(vgmstream, &mix);
 }
 
@@ -484,6 +485,7 @@ void mixing_push_volume(VGMSTREAM* vgmstream, int ch_dst, double volume) {
     mix.ch_dst = ch_dst;
     mix.vol = volume;
 
+    //;VGM_LOG("MIX: volume %i*%f\n", ch_dst,volume);
     add_mixing(vgmstream, &mix);
 }
 
@@ -648,7 +650,7 @@ void mixing_push_fade(VGMSTREAM* vgmstream, int ch_dst, double vol_start, double
         /* should only modify prev if add_mixing but meh */
     }
 
-    //;VGM_LOG("MIX: fade: %i^%f~%f=%c@%i~%i~%i~%i\n", ch_dst, vol_start, vol_end, shape, time_pre, time_start, time_end, time_post);
+    //;VGM_LOG("MIX: fade %i^%f~%f=%c@%i~%i~%i~%i\n", ch_dst, vol_start, vol_end, shape, time_pre, time_start, time_end, time_post);
     add_mixing(vgmstream, &mix);
 }
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -1205,6 +1205,9 @@ typedef struct {
     int64_t skipSamples; // number of start samples that will be skipped (encoder delay), for looping adjustments
     int streamCount; // number of FFmpeg audio streams
     
+    int channel_remap_set;
+    int channel_remap[32]; /* map of channel > new position */
+
     /*** internal state ***/
     // Intermediate byte buffer
     uint8_t *sampleBuffer;


### PR DESCRIPTION
- Add PCM .akb [Mobius Final Fantasy (Mobile)]
- Fix 5.1/7.1 .at3 LFE channel order [Devil May Cry 4 (PS3)]
- Fix TXTP "c" command and add "C" (`@track` alt)
- Improve txtp_maker -n option
- Fix layered current/loop sample (needed by TXTP)
