### PR TITLE
Up the max sample rate to 128K.

### DIFF
--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -10,7 +10,7 @@ enum { PATH_LIMIT = 32768 };
 enum { STREAM_NAME_SIZE = 255 };
 enum { VGMSTREAM_MAX_CHANNELS = 64 };
 enum { VGMSTREAM_MIN_SAMPLE_RATE = 300 }; /* 300 is Wwise min */
-enum { VGMSTREAM_MAX_SAMPLE_RATE = 96000 };
+enum { VGMSTREAM_MAX_SAMPLE_RATE = 128000 };
 enum { VGMSTREAM_MAX_SUBSONGS = 65535 };
 
 #include "streamfile.h"


### PR DESCRIPTION
While 96K already seems like a ridiculously high sample rate and that 128K should be discarded, I found that the in-game music for much of AI War: Fleet Command has a sample rate of 128K and will not play in vgmstream without this value being increaased.