### PR TITLE
txth vpk dsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ formats.
 ## Tagging
 Some of vgmstream's plugins support simple read-only tagging via external files.
 
-Tags are loaded from a text/M3U-like file named _!tags.m3u_ in the song folder.
+Tags are loaded from a text/M3U-like file named *!tags.m3u* in the song folder.
 You don't have to load your songs with that M3U though (but you can, for pre-made
 ordering), the file itself just 'looks' like an M3U.
 
@@ -279,13 +279,20 @@ _filename_ though, so any @TAG below would be ignored.
 
 Playlist formatting should follow player's config. ASCII or UTF-8 tags work.
 
-GLOBAL_COMMANDs currently can be: 
+GLOBAL_COMMANDs currently can be:
 - AUTOTRACK: sets %TRACK% tag automatically (1..N as files are encountered
   in the tag file).
 - AUTOALBUM: sets %ALBUM% tag automatically using the containing dir as album.
 
-foobar2000 can apply the following replaygain tags (if ReplayGain is enabled
-in foobar's preferences):
+Note that since you can use global tags don't need to put all files inside.
+This would be a perfectly valid *!tags.m3u*:
+```
+# @ALBUM    Game
+# @ARTIST   Various Artists
+```
+
+foobar2000/Winamp can apply the following replaygain tags (if ReplayGain is
+enabled in preferences):
 ```
 # %replaygain_track_gain N.NN dB
 # %replaygain_track_peak N.NNN

--- a/src/meta/fsb5_fev.c
+++ b/src/meta/fsb5_fev.c
@@ -1,7 +1,7 @@
 #include "meta.h"
 #include "../coding/coding.h"
 
-/* FEV+FSB5 container [Shantae: Half-Genie Hero (Switch)] */
+/* FEV+FSB5 container [Just Cause 3 (PC), Shantae: Half-Genie Hero (Switch)] */
 VGMSTREAM * init_vgmstream_fsb5_fev_bank(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     STREAMFILE *temp_streamFile = NULL;

--- a/src/meta/txth_streamfile.h
+++ b/src/meta/txth_streamfile.h
@@ -4,12 +4,18 @@
 
 
 typedef struct {
-    /* config */
-    off_t stream_offset;
-    size_t stream_size;
+    off_t chunk_start;
     size_t chunk_size;
+    size_t chunk_header_size;
+    size_t chunk_data_size;
     int chunk_count;
     int chunk_number;
+} txth_io_config_data;
+
+typedef struct {
+    /* config */
+    txth_io_config_data cfg;
+    size_t stream_size;
 
     /* state */
     off_t logical_offset;       /* fake offset */
@@ -28,7 +34,7 @@ static size_t txth_io_read(STREAMFILE *streamfile, uint8_t *dest, off_t offset, 
 
     /* re-start when previous offset (can't map logical<>physical offsets) */
     if (data->logical_offset < 0 || offset < data->logical_offset) {
-        data->physical_offset = data->stream_offset;
+        data->physical_offset = data->cfg.chunk_start;
         data->logical_offset = 0x00;
         data->data_size = 0;
         data->skip_size = 0;
@@ -38,15 +44,35 @@ static size_t txth_io_read(STREAMFILE *streamfile, uint8_t *dest, off_t offset, 
     while (length > 0) {
 
         /* ignore EOF */
-        if (offset < 0 || data->physical_offset >= data->stream_offset + data->stream_size) {
+        if (offset < 0 || data->physical_offset >= data->cfg.chunk_start + data->stream_size) {
             break;
         }
 
         /* process new block */
         if (data->data_size == 0) {
-            data->block_size = data->chunk_size * data->chunk_count;
-            data->skip_size = data->chunk_size * data->chunk_number;
-            data->data_size = data->chunk_size;
+            /* base sizes */
+            data->block_size = data->cfg.chunk_size * data->cfg.chunk_count;
+            data->skip_size = data->cfg.chunk_size * data->cfg.chunk_number;
+            data->data_size = data->cfg.chunk_size;
+
+            /* chunk size modifiers */
+            if (data->cfg.chunk_header_size) {
+                data->skip_size += data->cfg.chunk_header_size;
+                data->data_size -= data->cfg.chunk_header_size;
+            }
+            if (data->cfg.chunk_data_size) {
+                data->data_size = data->cfg.chunk_data_size;
+            }
+
+            /* clamp for games where last block is smaller */ //todo not correct for all cases
+            if (data->physical_offset + data->block_size > data->cfg.chunk_start + data->stream_size) {
+                data->block_size = (data->cfg.chunk_start + data->stream_size) - data->physical_offset;
+                data->skip_size = (data->block_size / data->cfg.chunk_count) * data->cfg.chunk_number;
+            }
+            if (data->physical_offset + data->data_size > data->cfg.chunk_start + data->stream_size) {
+                data->data_size = (data->cfg.chunk_start + data->stream_size) - data->physical_offset;
+            }
+
         }
 
         /* move to next block */
@@ -95,18 +121,15 @@ static size_t txth_io_size(STREAMFILE *streamfile, txth_io_data* data) {
 }
 
 /* Handles deinterleaving of generic chunked streams */
-static STREAMFILE* setup_txth_streamfile(STREAMFILE *streamFile, off_t chunk_start, size_t chunk_size, int chunk_count, int chunk_number, int is_opened_streamfile) {
+static STREAMFILE* setup_txth_streamfile(STREAMFILE *streamFile, txth_io_config_data cfg, int is_opened_streamfile) {
     STREAMFILE *temp_streamFile = NULL, *new_streamFile = NULL;
     txth_io_data io_data = {0};
     size_t io_data_size = sizeof(txth_io_data);
 
-    io_data.stream_offset = chunk_start;
-    io_data.stream_size = (get_streamfile_size(streamFile) - chunk_start);
-    io_data.chunk_size = chunk_size;
-    io_data.chunk_count = chunk_count;
-    io_data.chunk_number = chunk_number;
-    io_data.logical_size = io_data.stream_size / chunk_count;
+    io_data.cfg = cfg; /* memcpy */
+    io_data.stream_size = (get_streamfile_size(streamFile) - cfg.chunk_start);
     io_data.logical_offset = -1; /* force phys offset reset */
+    //io_data.logical_size = io_data.stream_size / cfg.chunk_count; //todo would help with performance but not ok if data_size is set
 
 
     new_streamFile = streamFile;

--- a/src/meta/ubi_bao.c
+++ b/src/meta/ubi_bao.c
@@ -1875,6 +1875,8 @@ static int config_bao_version(ubi_bao_header * bao, STREAMFILE *streamFile) {
              * - base varies per type (0xF0=audio), skip 0x20
              * - 0x74: type, 0x78: channels, 0x7c: sample rate, 0x80: num_samples
              * - 0x94: stream id? 0x9C: extra size */
+        case 0x002A0300: /* Watch Dogs (Wii U) */
+            /* similar to SC:B */
         default: /* others possibly using BAO: Just Dance, Watch_Dogs, Far Cry Primal, Far Cry 4 */
             VGM_LOG("UBI BAO: unknown BAO version %08x\n", bao->version);
             return 0;


### PR DESCRIPTION
- Fix VPK looping [Sly 2: Band of Thieves (PS2)]
- Add TXTH chunk_header_size/chunk_data_size for padding and fix fields
- Ignore some incorrectly detected interleaved .dsp
