### PR TITLE
txth xvag scd

### DIFF
--- a/src/coding/mpeg_custom_utils.c
+++ b/src/coding/mpeg_custom_utils.c
@@ -78,18 +78,23 @@ int mpeg_custom_setup_init_default(STREAMFILE *streamFile, off_t start_offset, m
 
     //todo: test more: this improves the output, but seems formats aren't usually prepared
     // (and/or the num_samples includes all possible samples in file, so by discarding some it'll reach EOF)
-#if 0
+
     /* set encoder delay (samples to skip at the beginning of a stream) if needed, which varies with encoder used */
     switch(data->type) {
-        case MPEG_AHX: data->skip_samples = 480; break; /* observed default */
-        case MPEG_P3D: data->skip_samples = info.frame_samples; break; /* matches Radical ADPCM (PC) output */
+        //case MPEG_AHX: data->skip_samples = 480; break; /* observed default */
+        //case MPEG_P3D: data->skip_samples = info.frame_samples; break; /* matches Radical ADPCM (PC) output */
+
         /* FSBs (with FMOD DLLs) don't seem to need it. Particularly a few games (all from Wayforward?)
          * contain audible garbage at the beginning, but it's actually there in-game too */
-        case MPEG_FSB: data->skip_samples = 0;
-        default: break;
+        //case MPEG_FSB: data->skip_samples = 0; break;
+
+        case MPEG_XVAG: /* set in header and needed for gapless looping */
+            data->skip_samples = data->config.skip_samples; break;
+        default:
+            break;
     }
     data->samples_to_discard = data->skip_samples;
-#endif
+
 
     return 1;
 fail:

--- a/src/meta/hd3_bd3.c
+++ b/src/meta/hd3_bd3.c
@@ -35,8 +35,13 @@ VGMSTREAM * init_vgmstream_hd3_bd3(STREAMFILE *streamFile) {
         if (read_32bitBE(section_offset+0x00,streamHeader) != 0x50335641) /* "P3VA" */
             goto fail;
         section_size = read_32bitBE(section_offset+0x04,streamHeader); /* (not including first 0x08) */
-        /* 0x08 always 0x10? */
-        entries = read_32bitBE(section_offset+0x14,streamHeader) + 1;
+        /* 0x08 size of all subsong headers + 0x10 */
+
+        entries = read_32bitBE(section_offset+0x14,streamHeader);
+        /* often there is an extra subsong than written, but may be padding instead */
+        if (read_32bitBE(section_offset + 0x20 + entries*0x10 + 0x04,streamHeader)) /* has sample rate */
+            entries += 1;
+
         if (entries * 0x10 > section_size) /* just in case, padding after entries is possible */
             goto fail;
 

--- a/src/meta/sqex_scd.c
+++ b/src/meta/sqex_scd.c
@@ -154,6 +154,7 @@ VGMSTREAM * init_vgmstream_sqex_scd(STREAMFILE *streamFile) {
 
         ovmi.meta_type = meta_SQEX_SCD;
         ovmi.total_subsongs = total_subsongs;
+        ovmi.disable_reordering = 1; /* already ordered */
         /* loop values are in bytes, let init_vgmstream_ogg_vorbis find loop comments instead */
 
         ogg_version = read_8bit(extradata_offset + 0x00, streamFile);

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -1030,6 +1030,7 @@ typedef struct {
     int interleave; /* size of stream interleave */
     int encryption; /* encryption mode */
     int big_endian;
+    int skip_samples;
     /* for AHX */
     int cri_type;
     uint16_t cri_key1;


### PR DESCRIPTION
- Fix multichannel Ogg .scd layout [Final Fantasy XIV]
- Fix XVAG MPEG encoder delay/gapless looping
- Fix subsongs in some .hd3+bd3
- Add TXTH base_offset, loop_behavior, improve math without spaces
- Add TXTH name_table