### PR TITLE
smk etc

### DIFF
--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -9,6 +9,11 @@
 
 static volatile int g_ffmpeg_initialized = 0;
 
+static void free_ffmpeg_config(ffmpeg_codec_data *data);
+static int init_ffmpeg_config(ffmpeg_codec_data * data, int target_subsong, int reset);
+
+static void reset_ffmpeg_internal(ffmpeg_codec_data *data);
+static void seek_ffmpeg_internal(ffmpeg_codec_data *data, int32_t num_sample);
 
 /* ******************************************** */
 /* INTERNAL UTILS                               */
@@ -114,7 +119,7 @@ static void convert_audio_pcm16(sample_t *outbuf, const uint8_t *inbuf, int full
  * Some formats may not seek to 0 even with this, though.
  */
 static int init_seek(ffmpeg_codec_data * data) {
-    int ret, ts_index, found_first = 0;
+    int ret, ts_index, packet_count = 0;
     int64_t ts = 0; /* seek timestamp */
     int64_t pos = 0; /* data offset */
     int size = 0; /* data size (block align) */
@@ -140,6 +145,7 @@ static int init_seek(ffmpeg_codec_data * data) {
 
 
     /* find the first + second packets to get pos/size */
+    packet_count = 0;
     while (1) {
         av_packet_unref(pkt);
         ret = av_read_frame(data->formatCtx, pkt);
@@ -148,8 +154,9 @@ static int init_seek(ffmpeg_codec_data * data) {
         if (pkt->stream_index != data->streamIndex)
             continue; /* ignore non-selected streams */
 
-        if (!found_first) {
-            found_first = 1;
+        //;VGM_LOG("FFMPEG: packet %i, ret=%i, pos=%i, dts=%i\n", packet_count, ret, (int32_t)pkt->pos, (int32_t)pkt->dts);
+        packet_count++;
+        if (packet_count == 1) {
             pos = pkt->pos;
             ts = pkt->dts;
             continue;
@@ -158,8 +165,13 @@ static int init_seek(ffmpeg_codec_data * data) {
             break;
         }
     }
-    if (!found_first)
+    if (packet_count == 0)
         goto fail;
+
+    /* happens in unseekable formats where FFmpeg doesn't even know its own position */
+    if (pos < 0)
+        goto fail;
+
     /* in rare cases there is only one packet */
     //if (size == 0) size = data_end - pos; /* no easy way to know, ignore (most formats don's need size) */
 
@@ -183,8 +195,10 @@ static int init_seek(ffmpeg_codec_data * data) {
 test_seek:
     /* seek to 0 test + move back to beginning, since we just consumed packets */
     ret = avformat_seek_file(data->formatCtx, data->streamIndex, ts, ts, ts, AVSEEK_FLAG_ANY);
-    if ( ret < 0 )
+    if ( ret < 0 ) {
+        //char test[1000] = {0}; av_strerror(ret, test, 1000); VGM_LOG("FFMPEG: ret=%i %s\n", ret, test);
         return ret; /* we can't even reset_vgmstream the file */
+    }
 
     avcodec_flush_buffers(data->codecCtx);
 
@@ -295,6 +309,7 @@ ffmpeg_codec_data * init_ffmpeg_header_offset(STREAMFILE *streamFile, uint8_t * 
     return init_ffmpeg_header_offset_subsong(streamFile, header, header_size, start, size, 0);
 }
 
+
 /**
  * Manually init FFmpeg, from a fake header / offset.
  *
@@ -306,28 +321,34 @@ ffmpeg_codec_data * init_ffmpeg_header_offset(STREAMFILE *streamFile, uint8_t * 
  */
 ffmpeg_codec_data * init_ffmpeg_header_offset_subsong(STREAMFILE *streamFile, uint8_t * header, uint64_t header_size, uint64_t start, uint64_t size, int target_subsong) {
     char filename[PATH_LIMIT];
-    ffmpeg_codec_data * data;
-    int errcode, i;
-    int streamIndex, streamCount;
+    ffmpeg_codec_data * data = NULL;
+    int errcode;
 
     AVStream *stream;
-    AVCodecParameters *codecPar = NULL;
     AVRational tb;
 
 
-    /* basic setup */
+    /* check values */
+    if ((header && !header_size) || (!header && header_size))
+        goto fail;
+
+    if (size == 0 || start + size > get_streamfile_size(streamFile)) {
+        VGM_LOG("FFMPEG: wrong start+size found: %x + %x > %x \n", (uint32_t)start, (uint32_t)size, get_streamfile_size(streamFile));
+        size = get_streamfile_size(streamFile) - start;
+    }
+
+
+    /* ffmpeg global setup */
     g_init_ffmpeg();
 
-    data = ( ffmpeg_codec_data * ) calloc(1, sizeof(ffmpeg_codec_data));
+
+    /* basic setup */
+    data = calloc(1, sizeof(ffmpeg_codec_data));
     if (!data) return NULL;
 
     streamFile->get_name( streamFile, filename, sizeof(filename) );
     data->streamfile = streamFile->open(streamFile, filename, STREAMFILE_DEFAULT_BUFFER_SIZE);
     if (!data->streamfile) goto fail;
-
-    /* ignore bad combos */
-    if ((header && !header_size) || (!header && header_size))
-        goto fail;
 
     /* fake header to trick FFmpeg into demuxing/decoding the stream */
     if (header_size > 0) {
@@ -337,91 +358,24 @@ ffmpeg_codec_data * init_ffmpeg_header_offset_subsong(STREAMFILE *streamFile, ui
     }
 
     data->start = start;
-    data->offset = start;
+    data->offset = data->start;
     data->size = size;
-    if (data->size == 0 || data->start + data->size > get_streamfile_size(streamFile)) {
-        VGM_LOG("FFPMEG: wrong start+size found: %x + %x > %x \n", (uint32_t)start, (uint32_t)size, get_streamfile_size(streamFile));
-        data->size = get_streamfile_size(streamFile) - data->start;
-    }
     data->logical_offset = 0;
     data->logical_size = data->header_size + data->size;
 
-    /* setup IO, attempt to autodetect format and gather some info */
-    data->buffer = av_malloc(FFMPEG_DEFAULT_IO_BUFFER_SIZE);
-    if (!data->buffer) goto fail;
 
-    data->ioCtx = avio_alloc_context(data->buffer, FFMPEG_DEFAULT_IO_BUFFER_SIZE, 0, data, ffmpeg_read, ffmpeg_write, ffmpeg_seek);
-    if (!data->ioCtx) goto fail;
+    /* setup FFmpeg's internals, attempt to autodetect format and gather some info */
+    errcode = init_ffmpeg_config(data, target_subsong, 0);
+    if (errcode < 0) goto fail;
 
-    data->formatCtx = avformat_alloc_context();
-    if (!data->formatCtx) goto fail;
-
-    data->formatCtx->pb = data->ioCtx;
-
-    if ((errcode = avformat_open_input(&data->formatCtx, "", NULL, NULL)) < 0) goto fail; /* autodetect */
-
-    if ((errcode = avformat_find_stream_info(data->formatCtx, NULL)) < 0) goto fail;
+    stream = data->formatCtx->streams[data->streamIndex];
 
 
-    /* find valid audio stream */
-    streamIndex = -1;
-    streamCount = 0;
-
-    for (i = 0; i < data->formatCtx->nb_streams; ++i) {
-        stream = data->formatCtx->streams[i];
-
-        if (stream->codecpar && stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-            streamCount++;
-
-            /* select Nth audio stream if specified, or first one */
-            if (streamIndex < 0 || (target_subsong > 0 && streamCount == target_subsong)) {
-                codecPar = stream->codecpar;
-                streamIndex = i;
-            }
-        }
-
-        if (i != streamIndex)
-            stream->discard = AVDISCARD_ALL; /* disable demuxing for other streams */
-    }
-    if (streamCount < target_subsong) goto fail;
-    if (streamIndex < 0 || !codecPar) goto fail;
-
-    data->streamIndex = streamIndex;
-    stream = data->formatCtx->streams[streamIndex];
-    data->streamCount = streamCount;
-
-
-    /* prepare codec and frame/packet buffers */
-    data->codecCtx = avcodec_alloc_context3(NULL);
-    if (!data->codecCtx) goto fail;
-
-    if ((errcode = avcodec_parameters_to_context(data->codecCtx, codecPar)) < 0) goto fail;
-
-    //av_codec_set_pkt_timebase(data->codecCtx, stream->time_base); /* deprecated and seemingly not needed */
-
-    data->codec = avcodec_find_decoder(data->codecCtx->codec_id);
-    if (!data->codec) goto fail;
-
-    if ((errcode = avcodec_open2(data->codecCtx, data->codec, NULL)) < 0) goto fail;
-
-    data->lastDecodedFrame = av_frame_alloc();
-    if (!data->lastDecodedFrame) goto fail;
-    av_frame_unref(data->lastDecodedFrame);
-
-    data->lastReadPacket = malloc(sizeof(AVPacket));
-    if (!data->lastReadPacket) goto fail;
-    av_new_packet(data->lastReadPacket, 0);
-
-    data->readNextPacket = 1;
-    data->bytesConsumedFromDecodedFrame = INT_MAX;
-
-
-
-    /* other setup */
+    /* derive info */
     data->sampleRate = data->codecCtx->sample_rate;
     data->channels = data->codecCtx->channels;
+    data->bitrate = (int)(data->codecCtx->bit_rate);
     data->floatingPoint = 0;
-
     switch (data->codecCtx->sample_fmt) {
         case AV_SAMPLE_FMT_U8:
         case AV_SAMPLE_FMT_U8P:
@@ -454,9 +408,11 @@ ffmpeg_codec_data * init_ffmpeg_header_offset_subsong(STREAMFILE *streamFile, ui
             goto fail;
     }
 
-    data->bitrate = (int)(data->codecCtx->bit_rate);
-    data->endOfStream = 0;
-    data->endOfAudio = 0;
+    /* setup decode buffer */
+    data->sampleBufferBlock = FFMPEG_DEFAULT_SAMPLE_BUFFER_SIZE;
+    data->sampleBuffer = av_malloc(data->sampleBufferBlock * (data->bitsPerSample / 8) * data->channels);
+    if (!data->sampleBuffer) goto fail;
+
 
     /* try to guess frames/samples (duration isn't always set) */
     tb.num = 1; tb.den = data->codecCtx->sample_rate;
@@ -469,19 +425,21 @@ ffmpeg_codec_data * init_ffmpeg_header_offset_subsong(STREAMFILE *streamFile, ui
     if(data->frameSize == 0) /* some formats don't set frame_size but can get on request, and vice versa */
         data->frameSize = av_get_audio_frame_duration(data->codecCtx,0);
 
-    /* setup decode buffer */
-    data->sampleBufferBlock = FFMPEG_DEFAULT_SAMPLE_BUFFER_SIZE;
-    data->sampleBuffer = av_malloc( data->sampleBufferBlock * (data->bitsPerSample / 8) * data->channels );
-    if (!data->sampleBuffer)
-        goto fail;
+
+    /* reset */
+    data->readNextPacket = 1;
+    data->bytesConsumedFromDecodedFrame = INT_MAX;
+    data->endOfStream = 0;
+    data->endOfAudio = 0;
 
 
-    /* setup decent seeking for faulty formats */
-    errcode = init_seek(data);
-    if (errcode < 0) {
-        VGM_LOG("FFMPEG: can't init_seek\n");
-        goto fail;
-    }
+    /* expose start samples to be skipped (encoder delay, usually added by MDCT-based encoders like AAC/MP3/ATRAC3/XMA/etc)
+     * get after init_seek because some demuxers like AAC only fill skip_samples for the first packet */
+    if (stream->start_skip_samples) /* samples to skip in the first packet */
+        data->skipSamples = stream->start_skip_samples;
+    else if (stream->skip_samples) /* samples to skip in any packet (first in this case), used sometimes instead (ex. AAC) */
+        data->skipSamples = stream->skip_samples;
+
 
     /* check ways to skip encoder delay/padding, for debugging purposes (some may be old/unused/encoder only/etc) */
     VGM_ASSERT(data->codecCtx->delay > 0, "FFMPEG: delay %i\n", (int)data->codecCtx->delay);//delay: OPUS
@@ -498,20 +456,107 @@ ffmpeg_codec_data * init_ffmpeg_header_offset_subsong(STREAMFILE *streamFile, ui
     //todo: double check Opus behavior
 
 
-    /* expose start samples to be skipped (encoder delay, usually added by MDCT-based encoders like AAC/MP3/ATRAC3/XMA/etc)
-     * get after init_seek because some demuxers like AAC only fill skip_samples for the first packet */
-    if (stream->start_skip_samples) /* samples to skip in the first packet */
-        data->skipSamples = stream->start_skip_samples;
-    else if (stream->skip_samples) /* samples to skip in any packet (first in this case), used sometimes instead (ex. AAC) */
-        data->skipSamples = stream->skip_samples;
+    /* setup decent seeking for faulty formats */
+    errcode = init_seek(data);
+    if (errcode < 0) {
+        VGM_LOG("FFMPEG: can't init_seek, error=%i\n", errcode);
+        /* some formats like Smacker are so buggy that any seeking is impossible (even on video players)
+         * whatever, we'll just kill and reconstruct FFmpeg's config every time */
+        data->force_seek = 1;
+        reset_ffmpeg_internal(data); /* reset state from trying to seek */
+        //stream = data->formatCtx->streams[data->streamIndex];
+    }
 
     return data;
-
 fail:
     free_ffmpeg(data);
-
     return NULL;
 }
+
+static int init_ffmpeg_config(ffmpeg_codec_data * data, int target_subsong, int reset) {
+    int errcode = 0;
+
+    /* basic IO/format setup */
+    data->buffer = av_malloc(FFMPEG_DEFAULT_IO_BUFFER_SIZE);
+    if (!data->buffer) goto fail;
+
+    data->ioCtx = avio_alloc_context(data->buffer, FFMPEG_DEFAULT_IO_BUFFER_SIZE, 0, data, ffmpeg_read, ffmpeg_write, ffmpeg_seek);
+    if (!data->ioCtx) goto fail;
+
+    data->formatCtx = avformat_alloc_context();
+    if (!data->formatCtx) goto fail;
+
+    data->formatCtx->pb = data->ioCtx;
+
+    //on reset could use AVFormatContext.iformat to reload old format
+    errcode = avformat_open_input(&data->formatCtx, "", NULL, NULL);
+    if (errcode < 0) goto fail;
+
+    errcode = avformat_find_stream_info(data->formatCtx, NULL);
+    if (errcode < 0) goto fail;
+
+    /* find valid audio stream and set other streams to discard */
+    {
+        int i, streamIndex, streamCount;
+
+        streamIndex = -1;
+        streamCount = 0;
+        if (reset)
+            streamIndex = data->streamIndex;
+
+        for (i = 0; i < data->formatCtx->nb_streams; ++i) {
+            AVStream *stream = data->formatCtx->streams[i];
+
+            if (stream->codecpar && stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+                streamCount++;
+
+                /* select Nth audio stream if specified, or first one */
+                if (streamIndex < 0 || (target_subsong > 0 && streamCount == target_subsong)) {
+                    streamIndex = i;
+                }
+            }
+
+            if (i != streamIndex)
+                stream->discard = AVDISCARD_ALL; /* disable demuxing for other streams */
+        }
+        if (streamCount < target_subsong) goto fail;
+        if (streamIndex < 0) goto fail;
+
+        data->streamIndex = streamIndex;
+        data->streamCount = streamCount;
+    }
+
+    /* setup codec with stream info */
+    data->codecCtx = avcodec_alloc_context3(NULL);
+    if (!data->codecCtx) goto fail;
+
+    errcode = avcodec_parameters_to_context(data->codecCtx, ((AVStream*)data->formatCtx->streams[data->streamIndex])->codecpar);
+    if (errcode < 0) goto fail;
+
+    //av_codec_set_pkt_timebase(data->codecCtx, stream->time_base); /* deprecated and seemingly not needed */
+
+    data->codec = avcodec_find_decoder(data->codecCtx->codec_id);
+    if (!data->codec) goto fail;
+
+    errcode = avcodec_open2(data->codecCtx, data->codec, NULL);
+    if (errcode < 0) goto fail;
+
+    /* prepare codec and frame/packet buffers */
+    data->lastDecodedFrame = av_frame_alloc();
+    if (!data->lastDecodedFrame) goto fail;
+    av_frame_unref(data->lastDecodedFrame);
+
+    data->lastReadPacket = malloc(sizeof(AVPacket));
+    if (!data->lastReadPacket) goto fail;
+    av_new_packet(data->lastReadPacket, 0);
+
+    return 0;
+fail:
+    if (errcode < 0)
+        return errcode;
+    return -1;
+}
+
 
 /* decode samples of any kind of FFmpeg format */
 void decode_ffmpeg(VGMSTREAM *vgmstream, sample_t * outbuf, int32_t samples_to_do, int channels) {
@@ -523,16 +568,21 @@ void decode_ffmpeg(VGMSTREAM *vgmstream, sample_t * outbuf, int32_t samples_to_d
     AVCodecContext *codecCtx = data->codecCtx;
     AVPacket *packet = data->lastReadPacket;
     AVFrame *frame = data->lastDecodedFrame;
-    int planar = av_sample_fmt_is_planar(data->codecCtx->sample_fmt);
 
     int readNextPacket = data->readNextPacket;
     int endOfStream = data->endOfStream;
     int endOfAudio = data->endOfAudio;
     int bytesConsumedFromDecodedFrame = data->bytesConsumedFromDecodedFrame;
 
+    int planar = 0;
     int bytesPerSample = data->bitsPerSample / 8;
     int bytesRead, bytesToRead;
 
+
+    if (data->bad_init) {
+        memset(outbuf, 0, samples_to_do * channels * sizeof(sample));
+        return;
+    }
 
     /* ignore once file is done (but not at endOfStream as FFmpeg can still output samples until endOfAudio) */
     if (/*endOfStream ||*/ endOfAudio) {
@@ -541,6 +591,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream, sample_t * outbuf, int32_t samples_to_d
         return;
     }
 
+    planar = av_sample_fmt_is_planar(codecCtx->sample_fmt);
     bytesRead = 0;
     bytesToRead = samples_to_do * (bytesPerSample * codecCtx->channels);
 
@@ -587,7 +638,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream, sample_t * outbuf, int32_t samples_to_d
                     goto end;
                 }
             }
-            
+
             readNextPacket = 0; /* got compressed data */
         }
 
@@ -696,21 +747,44 @@ end:
 /* UTILS                                        */
 /* ******************************************** */
 
+void reset_ffmpeg_internal(ffmpeg_codec_data *data) {
+    seek_ffmpeg_internal(data, 0);
+}
 void reset_ffmpeg(VGMSTREAM *vgmstream) {
-    ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
+    reset_ffmpeg_internal(vgmstream->codec_data);
+}
+
+void seek_ffmpeg_internal(ffmpeg_codec_data *data, int32_t num_sample) {
     if (!data) return;
 
-    if (data->formatCtx) {
-        avformat_seek_file(data->formatCtx, data->streamIndex, 0, 0, 0, AVSEEK_FLAG_ANY);
+    /* Start from 0 and discard samples until sample (slower but not too noticeable).
+     * Due to various FFmpeg quirks seeking to a sample is erratic in many formats (would need extra steps). */
+
+    if (data->force_seek) {
+        int errcode;
+
+        /* kill+redo everything to allow seeking for extra-buggy formats,
+         * kinda horrid but seems fast enough and very few formats need this */
+
+        free_ffmpeg_config(data);
+
+        data->offset = data->start;
+        data->logical_offset = 0;
+
+        errcode = init_ffmpeg_config(data, 0, 1);
+        if (errcode < 0) goto fail;
     }
-    if (data->codecCtx) {
+    else {
+        avformat_seek_file(data->formatCtx, data->streamIndex, 0, 0, 0, AVSEEK_FLAG_ANY);
         avcodec_flush_buffers(data->codecCtx);
     }
+
+    data->samplesToDiscard = num_sample;
+
     data->readNextPacket = 1;
     data->bytesConsumedFromDecodedFrame = INT_MAX;
     data->endOfStream = 0;
     data->endOfAudio = 0;
-    data->samplesToDiscard = 0;
 
     /* consider skip samples (encoder delay), if manually set (otherwise let FFmpeg handle it) */
     if (data->skipSamplesSet) {
@@ -721,39 +795,19 @@ void reset_ffmpeg(VGMSTREAM *vgmstream) {
 
         data->samplesToDiscard += data->skipSamples;
     }
+
+    return;
+fail:
+    VGM_LOG("FFMPEG: error during force_seek\n");
+    data->bad_init = 1; /* internals were probably free'd */
 }
 
 void seek_ffmpeg(VGMSTREAM *vgmstream, int32_t num_sample) {
-    ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
-    int64_t ts;
-    if (!data)
-        return;
-
-    /* Start from 0 and discard samples until loop_start (slower but not too noticeable).
-     * Due to various FFmpeg quirks seeking to a sample is erratic in many formats (would need extra steps). */
-    data->samplesToDiscard = num_sample;
-    ts = 0;
-
-    avformat_seek_file(data->formatCtx, data->streamIndex, ts, ts, ts, AVSEEK_FLAG_ANY);
-    avcodec_flush_buffers(data->codecCtx);
-
-    data->readNextPacket = 1;
-    data->bytesConsumedFromDecodedFrame = INT_MAX;
-    data->endOfStream = 0;
-    data->endOfAudio = 0;
-
-    /* consider skip samples (encoder delay), if manually set (otherwise let FFmpeg handle it) */
-    if (data->skipSamplesSet) {
-        AVStream *stream = data->formatCtx->streams[data->streamIndex];
-        /* sometimes (ex. AAC) after seeking to the first packet skip_samples is restored, but we want our value */
-        stream->skip_samples = 0;
-        stream->start_skip_samples = 0;
-
-        data->samplesToDiscard += data->skipSamples;
-    }
+    seek_ffmpeg_internal(vgmstream->codec_data, num_sample);
 }
 
-void free_ffmpeg(ffmpeg_codec_data *data) {
+
+static void free_ffmpeg_config(ffmpeg_codec_data *data) {
     if (data == NULL)
         return;
 
@@ -786,6 +840,14 @@ void free_ffmpeg(ffmpeg_codec_data *data) {
         av_free(data->buffer);
         data->buffer = NULL;
     }
+}
+
+void free_ffmpeg(ffmpeg_codec_data *data) {
+    if (data == NULL)
+        return;
+
+    free_ffmpeg_config(data);
+
     if (data->sampleBuffer) {
         av_free(data->sampleBuffer);
         data->sampleBuffer = NULL;
@@ -794,10 +856,8 @@ void free_ffmpeg(ffmpeg_codec_data *data) {
         av_free(data->header_insert_block);
         data->header_insert_block = NULL;
     }
-    if (data->streamfile) {
-        close_streamfile(data->streamfile);
-        data->streamfile = NULL;
-    }
+
+    close_streamfile(data->streamfile);
     free(data);
 }
 
@@ -813,7 +873,7 @@ void free_ffmpeg(ffmpeg_codec_data *data) {
  */
 void ffmpeg_set_skip_samples(ffmpeg_codec_data * data, int skip_samples) {
     AVStream *stream = NULL;
-    if (!data->formatCtx)
+    if (!data || !data->formatCtx)
         return;
 
     /* overwrite FFmpeg's skip samples */

--- a/src/formats.c
+++ b/src/formats.c
@@ -433,7 +433,7 @@ static const char* extension_list[] = {
     "swag",
     "swav",
     "swd",
-    "switch_audio"
+    "switch_audio",
     "sx",
     "sxd",
     "sxd2",

--- a/src/formats.c
+++ b/src/formats.c
@@ -398,6 +398,7 @@ static const char* extension_list[] = {
     "slb", //txth/reserved [THE Nekomura no Hitobito (PS2)]
     "sli",
     "smc",
+    "smk",
     "smp",
     "smpl", //fake extension/header id for .v0/v1 (renamed, to be removed)
     "smv",
@@ -1198,7 +1199,8 @@ static const meta_info meta_info_list[] = {
         {meta_XWMA_KONAMI,          "Konami XWMA header"},
         {meta_9TAV,                 "Konami 9TAV header"},
         {meta_BWAV,                 "Nintendo BWAV header"},
-        {meta_RAD,                  "Traveller's Tales RAD header"},
+        {meta_RAD,                  "Traveller's Tales .RAD header"},
+        {meta_SMACKER,              "RAD Game Tools SMACKER header"},
 
 };
 

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -1475,6 +1475,10 @@
                     >
                 </File>
                 <File
+                    RelativePath=".\meta\smk.c"
+                    >
+                </File>
+                <File
                     RelativePath=".\meta\smp.c"
                     >
                 </File>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -457,6 +457,7 @@
     <ClCompile Include="meta\sfl.c" />
     <ClCompile Include="meta\sli.c" />
     <ClCompile Include="meta\smc_smh.c" />
+    <ClCompile Include="meta\smk.c" />
     <ClCompile Include="meta\smp.c" />
     <ClCompile Include="meta\smv.c" />
     <ClCompile Include="meta\sps_n1.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -913,6 +913,9 @@
     <ClCompile Include="meta\smc_smh.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\smk.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\smp.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/acb.c
+++ b/src/meta/acb.c
@@ -132,8 +132,7 @@ static int load_utf_subtable(STREAMFILE *acbFile, acb_header* acb, utf_context* 
     *Table = utf_open(acbFile, offset, rows, NULL);
     if (!*Table) goto fail;
 
-
-    ;VGM_LOG("ACB: loaded table %s\n", TableName);
+    //;VGM_LOG("ACB: loaded table %s\n", TableName);
     return 1;
 fail:
     return 0;
@@ -146,7 +145,7 @@ static int load_acb_cue_info(STREAMFILE *acbFile, acb_header* acb) {
         goto fail;
     if (!utf_query_string(acbFile, acb->CueNameTable, acb->CueNameIndex, "CueName", &acb->CueName))
         goto fail;
-    ;VGM_LOG("ACB: CueName[%i]: CueIndex=%i, CueName=%s\n", acb->CueNameIndex, acb->CueIndex, acb->CueName);
+    //;VGM_LOG("ACB: CueName[%i]: CueIndex=%i, CueName=%s\n", acb->CueNameIndex, acb->CueIndex, acb->CueName);
 
     /* read Cue[CueIndex] */
     if (!load_utf_subtable(acbFile, acb, &acb->CueTable, "CueTable", NULL))
@@ -155,7 +154,7 @@ static int load_acb_cue_info(STREAMFILE *acbFile, acb_header* acb) {
         goto fail;
     if (!utf_query_s16(acbFile, acb->CueTable, acb->CueIndex, "ReferenceIndex", &acb->ReferenceIndex))
         goto fail;
-    ;VGM_LOG("ACB: Cue[%i]: ReferenceType=%i, ReferenceIndex=%i\n", acb->CueIndex, acb->ReferenceType, acb->ReferenceIndex);
+    //;VGM_LOG("ACB: Cue[%i]: ReferenceType=%i, ReferenceIndex=%i\n", acb->CueIndex, acb->ReferenceType, acb->ReferenceIndex);
 
     return 1;
 fail:
@@ -171,7 +170,7 @@ static int load_acb_sequence(STREAMFILE *acbFile, acb_header* acb) {
         goto fail;
     if (!utf_query_data(acbFile, acb->SequenceTable, acb->ReferenceIndex, "TrackIndex", &acb->TrackIndex_offset, &acb->TrackIndex_size))
         goto fail;
-    ;VGM_LOG("ACB: Sequence[%i]: NumTracks=%i, TrackIndex={%x, %x}\n", acb->ReferenceIndex, acb->NumTracks, acb->TrackIndex_offset,acb->TrackIndex_size);
+    //;VGM_LOG("ACB: Sequence[%i]: NumTracks=%i, TrackIndex={%x, %x}\n", acb->ReferenceIndex, acb->NumTracks, acb->TrackIndex_offset,acb->TrackIndex_size);
 
     if (acb->NumTracks * 0x02 > acb->TrackIndex_size) { /* padding may exist */
         VGM_LOG("ACB: unknown TrackIndex size\n");
@@ -190,7 +189,7 @@ static int load_acb_track_command(STREAMFILE *acbFile, acb_header* acb) {
         goto fail;
     if (!utf_query_s16(acbFile, acb->TrackTable, acb->TrackIndex, "EventIndex", &acb->EventIndex))
         goto fail;
-    ;VGM_LOG("ACB: Track[%i]: EventIndex=%i\n", acb->TrackIndex, acb->EventIndex);
+    //;VGM_LOG("ACB: Track[%i]: EventIndex=%i\n", acb->TrackIndex, acb->EventIndex);
 
     /* depending on version next stuff varies a bit, check by table existence */
     if (acb->has_TrackEventTable) {
@@ -199,7 +198,7 @@ static int load_acb_track_command(STREAMFILE *acbFile, acb_header* acb) {
             goto fail;
         if (!utf_query_data(acbFile, acb->TrackEventTable, acb->EventIndex, "Command", &acb->Command_offset, &acb->Command_size))
             goto fail;
-        ;VGM_LOG("ACB: TrackEvent[%i]: Command={%x,%x}\n", acb->EventIndex, acb->Command_offset,acb->Command_size);
+        //;VGM_LOG("ACB: TrackEvent[%i]: Command={%x,%x}\n", acb->EventIndex, acb->Command_offset,acb->Command_size);
     }
     else if (acb->has_CommandTable) {
         /* read Command[EventIndex] */
@@ -207,7 +206,7 @@ static int load_acb_track_command(STREAMFILE *acbFile, acb_header* acb) {
             goto fail;
         if (!utf_query_data(acbFile, acb->CommandTable, acb->EventIndex, "Command", &acb->Command_offset, &acb->Command_size))
             goto fail;
-        ;VGM_LOG("ACB: Command[%i]: Command={%x,%x}\n", acb->EventIndex, acb->Command_offset,acb->Command_size);
+        //;VGM_LOG("ACB: Command[%i]: Command={%x,%x}\n", acb->EventIndex, acb->Command_offset,acb->Command_size);
     }
     else {
         VGM_LOG("ACB: unknown command table\n");
@@ -237,8 +236,10 @@ static int load_acb_track_command(STREAMFILE *acbFile, acb_header* acb) {
                 subindex = read_u16be(offset + 0x02, acbFile);
 
                 /* reference to Synth/Waveform like those in Synth? */
-                if (subcode != 0x02) { //todo some in Yakuza Kiwami 2 usen.acb use 03 (random? see Synth)
-                    VGM_LOG("ACB: subcommand with unknown subcode\n");
+                if (subcode != 0x02) {
+                    //todo some like Yakuza Kiwami 2 usen.acb/Yakuza 6 haichi_amb_siren.acb use 0x03
+                    // ('random' type pointing to Sequence, see Synth)
+                    VGM_LOG("ACB: subcommand with unknown subcode at %x\n", offset);
                     break;
                 }
 
@@ -247,7 +248,7 @@ static int load_acb_track_command(STREAMFILE *acbFile, acb_header* acb) {
                 if (acb->SynthIndex_count >= 254)
                     acb->ReferenceItems_count = 254; /* ??? */
 
-                ;VGM_LOG("ACB: subcommand index %i found\n", subindex);
+                //;VGM_LOG("ACB: subcommand index %i found\n", subindex);
             }
 
             /* 0x07D1 comes suspiciously often paired with 0x07D0 too */
@@ -271,7 +272,7 @@ static int load_acb_synth(STREAMFILE *acbFile, acb_header* acb) {
         goto fail;
     if (!utf_query_data(acbFile, acb->SynthTable, acb->SynthIndex, "ReferenceItems", &acb->ReferenceItems_offset, &acb->ReferenceItems_size))
         goto fail;
-    ;VGM_LOG("ACB: Synth[%i]: ReferenceItems={%x,%x}\n", acb->SynthIndex, acb->ReferenceItems_offset, acb->ReferenceItems_size);
+    //;VGM_LOG("ACB: Synth[%i]: ReferenceItems={%x,%x}\n", acb->SynthIndex, acb->ReferenceItems_offset, acb->ReferenceItems_size);
 
 
     acb->ReferenceItems_count = acb->ReferenceItems_size / 0x04;
@@ -298,7 +299,7 @@ static int load_acb_synth(STREAMFILE *acbFile, acb_header* acb) {
 
         type  = read_u16be(acb->ReferenceItems_offset + i*0x04 + 0x00, acbFile);
         index = read_u16be(acb->ReferenceItems_offset + i*0x04 + 0x02, acbFile);
-        ;VGM_LOG("ACB: Synth reference type=%x, index=%x\n", type, index);
+        //;VGM_LOG("ACB: Synth reference type=%x, index=%x\n", type, index);
 
         switch(type) {
             case 0x00: /* no reference */
@@ -329,19 +330,11 @@ static int load_acb_synth(STREAMFILE *acbFile, acb_header* acb) {
                 }
 
                 acb->ReferenceItems_list[i] = subindex;
-                ;VGM_LOG("ACB: Synth subreference type=%x, index=%x\n", subtype, subindex);
+                //;VGM_LOG("ACB: Synth subreference type=%x, index=%x\n", subtype, subindex);
                 break;
 
             case 0x03: /* random Synths with % in TrackValues (rare, found in Sonic Lost World with ReferenceType 2) */
-                //todo fix
-                /* this points to next? N Synths (in turn pointing to a Waveform), but I see no relation between
-                 * index value and pointed Synths plus those Synths don't seem referenced otherwise.
-                 * ex. se_phantom_asteroid.acb
-                 *  Synth[26] with index 7 points to Synth[27/28]
-                 *  Synth[26] with index 6 points to Synth[24/25]
-                 *  Synth[26] with index 8 points to Synth[29/30]
-                 *  Synth[26] with index 9 points to Synth[32/33] (Synth[30] is another random Type 3)
-                 */
+                //todo fix: points to N Sequences (in turn pointing to Tracks > Synths) ex. se_phantom_asteroid.acb
             default: /* undefined/crashes AtomViewer */
                 VGM_LOG("ACB: unknown Synth reference type\n");
                 acb->ReferenceItems_count = 0;
@@ -370,7 +363,7 @@ static int load_acb_waveform(STREAMFILE *acbFile, acb_header* acb, int waveid) {
                 goto fail;
         }
     }
-    ;VGM_LOG("ACB: Waveform[%i]: AwbId=%i, AwbStreaming=%i\n", acb->ReferenceItem, acb->AwbId, acb->AwbStreaming);
+    //;VGM_LOG("ACB: Waveform[%i]: AwbId=%i, AwbStreaming=%i\n", acb->ReferenceItem, acb->AwbId, acb->AwbStreaming);
 
     acb->is_wave_found = 0; /* reset */
 
@@ -418,7 +411,7 @@ static void add_acb_name(STREAMFILE *acbFile, acb_header* acb) {
     if (acb->AwbName_count >= 254)
         acb->AwbName_count = 254; /* ??? */
 
-    ;VGM_LOG("ACB: found cue for waveid=%i: %s\n", acb->AwbId, acb->CueName);
+    //;VGM_LOG("ACB: found cue for waveid=%i: %s\n", acb->AwbId, acb->CueName);
 }
 
 
@@ -450,7 +443,7 @@ void load_acb_wave_name(STREAMFILE *acbFile, VGMSTREAM* vgmstream, int waveid, i
      *   Atom Craft may only target certain .acb versions
      */
 
-    ;VGM_LOG("ACB: find waveid=%i\n", waveid);
+    //;VGM_LOG("ACB: find waveid=%i\n", waveid);
 
     acb.Header = utf_open(acbFile, 0x00, NULL, NULL);
     if (!acb.Header) goto done;
@@ -462,7 +455,7 @@ void load_acb_wave_name(STREAMFILE *acbFile, VGMSTREAM* vgmstream, int waveid, i
 
     /* read CueName[i] */
     if (!load_utf_subtable(acbFile, &acb, &acb.CueNameTable, "CueNameTable", &CueName_rows)) goto done;
-    ;VGM_LOG("ACB: CueNames=%i\n", CueName_rows);
+    //;VGM_LOG("ACB: CueNames=%i\n", CueName_rows);
 
     for (CueName_i = 0; CueName_i < CueName_rows; CueName_i++) {
         acb.CueNameIndex = CueName_i;

--- a/src/meta/aifc.c
+++ b/src/meta/aifc.c
@@ -73,8 +73,9 @@ VGMSTREAM * init_vgmstream_aifc(STREAMFILE *streamFile) {
      * .bgm: Super Street Fighter II Turbo (3DO)
      * .acm: Crusader - No Remorse (SAT)
      * .adp: Sonic Jam (SAT)
-     * .ai: Dragon Force (SAT) */
-    if (check_extensions(streamFile, "aif,laif")) {
+     * .ai: Dragon Force (SAT)
+     * (extensionless: Doom (3DO) */
+    if (check_extensions(streamFile, "aif,laif,")) {
         is_aifc_ext = 1;
         is_aiff_ext = 1;
     }

--- a/src/meta/ea_schl.c
+++ b/src/meta/ea_schl.c
@@ -118,14 +118,15 @@ VGMSTREAM * init_vgmstream_ea_schl(STREAMFILE *streamFile) {
     /* they don't seem enforced by EA's tools but usually:
      * .asf: ~early (audio stream file?) [ex. Need for Speed II (PC)]
      * .lasf: fake for plugins
-     * .str: ~early [ex. FIFA 2002 (PS1)]
-     * .eam: ~mid (fake?)
+     * .str: ~early [ex. FIFA 98 (PS1), FIFA 2002 (PS1)]
+     * .eam: ~mid?
      * .exa: ~mid [ex. 007 - From Russia with Love]
      * .sng: ~late (FIFA games)
      * .aud: ~late [ex. FIFA 14 (3DS)]
      * .strm: MySims Kingdom (Wii)
      * .stm: FIFA 12 (3DS)
-     * .sx/xa: fake?
+     * .sx: FIFA 98 (SAT)
+     * .xa: ?
      * .hab: GoldenEye - Rogue Agent (inside .big)
      * .xsf: 007 - Agent Under Fire (Xbox)
      * .gsf: 007 - Everything or Nothing (GC)

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -867,4 +867,6 @@ void load_acb_wave_name(STREAMFILE *acbFile, VGMSTREAM* vgmstream, int waveid, i
 
 VGMSTREAM * init_vgmstream_rad(STREAMFILE * streamFile);
 
+VGMSTREAM * init_vgmstream_smk(STREAMFILE * streamFile);
+
 #endif /*_META_H*/

--- a/src/meta/ngc_dsp_std.c
+++ b/src/meta/ngc_dsp_std.c
@@ -253,8 +253,9 @@ VGMSTREAM * init_vgmstream_ngc_dsp_std(STREAMFILE *streamFile) {
 
     /* checks */
     /* .dsp: standard
-     * .adp: Dr. Muto/Battalion Wars (GC) mono files */
-    if (!check_extensions(streamFile, "dsp,adp"))
+     * .adp: Dr. Muto/Battalion Wars (GC) mono files
+     * (extensionless): Tony Hawk's Downhill Jam (Wii) */
+    if (!check_extensions(streamFile, "dsp,adp,"))
         goto fail;
 
     if (read_dsp_header(&header, 0x00, streamFile))

--- a/src/meta/s14_sss.c
+++ b/src/meta/s14_sss.c
@@ -25,11 +25,13 @@ VGMSTREAM * init_vgmstream_s14_sss(STREAMFILE *streamFile) {
         char filename[PATH_LIMIT];
         streamFile->get_name(streamFile,filename,sizeof(filename));
 
-        /* horrid but I ain't losing sleep over it (besides the header must be somewhere as some tracks loop) */
-        if (strstr(filename,"S037")==filename || strstr(filename,"b06")==filename) /* Korogashi Puzzle Katamari Damacy */
+        /* horrid but I ain't losing sleep over it (besides the header is often incrusted in-code as some tracks loop) */
+        if (strstr(filename,"S037")==filename || strstr(filename,"b06")==filename || /* Korogashi Puzzle Katamari Damacy */
+            strstr(filename,"_48kbps")!=NULL) /* Taiko no Tatsujin DS 1/2 */
             interleave = 0x78;
         else if (strstr(filename,"32700")==filename || /* Hottarake no Shima - Kanata to Nijiiro no Kagami */
-                (strstr(filename,"b0")==filename || strstr(filename,"puzzle")==filename || strstr(filename,"M09")==filename) ) /* Korogashi Puzzle Katamari Damacy */
+                 strstr(filename,"b0")==filename || strstr(filename,"puzzle")==filename || strstr(filename,"M09")==filename || /* Korogashi Puzzle Katamari Damacy */
+                 strstr(filename,"_32kbps")!=NULL) /* Taiko no Tatsujin DS 1/2 */
             interleave = 0x50;
         else
             interleave = 0x3c; /* The Idolm@ster - Dearly Stars */

--- a/src/meta/smk.c
+++ b/src/meta/smk.c
@@ -1,0 +1,187 @@
+#include "meta.h"
+#include "../coding/coding.h"
+#include "../util.h"
+
+static int smacker_get_info(STREAMFILE *streamFile, int target_subsong, int * out_total_streams, size_t *out_stream_size, int * out_channel_count, int * out_sample_rate, int * out_num_samples);
+
+/* SMK - RAD Game Tools Smacker movies (audio/video format) */
+VGMSTREAM * init_vgmstream_smk(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    int channel_count = 0, loop_flag = 0, sample_rate = 0, num_samples = 0;
+    int total_subsongs = 0, target_subsong = streamFile->stream_index;
+    size_t stream_size;
+
+
+    /* checks */
+    if (!check_extensions(streamFile,"smk"))
+        goto fail;
+
+    if (read_32bitBE(0x00,streamFile) != 0x534D4B32 &&  /* "SMK2" */
+        read_32bitBE(0x00,streamFile) != 0x534D4B34)    /* "SMK4" */
+        goto fail;
+
+    /* find target stream info */
+    if (!smacker_get_info(streamFile, target_subsong, &total_subsongs, &stream_size, &channel_count, &sample_rate, &num_samples))
+        goto fail;
+
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channel_count, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->layout_type = layout_none;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->num_samples = num_samples;
+    vgmstream->num_streams = total_subsongs;
+    vgmstream->stream_size = stream_size;
+    vgmstream->meta_type = meta_SMACKER;
+
+    {
+#ifdef VGM_USE_FFMPEG
+        /* target_subsong should be passed manually */
+        vgmstream->codec_data = init_ffmpeg_header_offset_subsong(streamFile, NULL,0, 0x0,get_streamfile_size(streamFile), target_subsong);
+        if (!vgmstream->codec_data) goto fail;
+        vgmstream->coding_type = coding_FFmpeg;
+#else
+        goto fail;
+#endif
+    }
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
+typedef enum {
+    SMK_AUDIO_PACKED    = (1<<7),
+    SMK_AUDIO_PRESENT   = (1<<6),
+    SMK_AUDIO_16BITS    = (1<<5),
+    SMK_AUDIO_STEREO    = (1<<4),
+    SMK_AUDIO_BINK_RDFT = (1<<3),
+    SMK_AUDIO_BINK_DCT  = (1<<2),
+  //SMK_AUD_UNUSED1     = (1<<1),
+  //SMK_AUD_UNUSED0     = (1<<0),
+} smk_audio_flag;
+
+//todo test multilang streams and codecs other than SMACKAUD
+/* Gets stream info, and number of samples in a file by reading frames
+ * info: https://wiki.multimedia.cx/index.php/Smacker */
+static int smacker_get_info(STREAMFILE *sf, int target_subsong, int * out_total_subsongs, size_t * out_stream_size, int * out_channel_count, int * out_sample_rate, int * out_num_samples) {
+    STREAMFILE *sf_index = NULL;
+    uint32_t flags, total_frames, trees_sizes;
+    off_t size_offset, type_offset, data_offset;
+    int i, j, sample_rate = 0, channel_count = 0, num_samples = 0;
+    int total_subsongs, target_stream = 0;
+    size_t stream_size = 0;
+    uint8_t stream_flags = 0;
+    
+    
+    /* rough format:
+     * - header (id, frames, video info/config, audio info)
+     * - frame sizes table
+     * - frame info table
+     * - huffman trees
+     * - frame data
+     */
+
+    /* read header */
+    total_frames = read_u32le(0x0c,sf);
+    if (total_frames <= 0 || total_frames > 0x100000) goto fail; /* something must be off */
+
+    flags = read_u32le(0x14,sf);
+    if (flags & 1) /* extra "ring frame" */
+        total_frames += 1;
+
+    trees_sizes = read_u32le(0x34,sf);
+
+    if (target_subsong == 0) target_subsong = 1;
+    total_subsongs = 0;
+    for (i = 0; i < 7; i++) { /* up to 7 audio (multilang?) streams */
+        uint32_t audio_info = read_u32le(0x48 + 0x04*i,sf);
+        uint8_t audio_flags = (audio_info >> 24) & 0xFF;
+        int audio_rate = audio_info & 0x00FFFFFF;
+
+        if (audio_flags & SMK_AUDIO_PRESENT) {
+            total_subsongs++;
+            
+            if (target_subsong == total_subsongs) {
+                target_stream = i;
+                sample_rate = audio_rate & 0x00FFFFFF;
+                channel_count = (audio_flags & SMK_AUDIO_STEREO) ? 2 : 1;
+                stream_flags = audio_flags;
+            }
+        }
+    }
+    if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
+    if (sample_rate == 0 || channel_count == 0) goto fail;
+
+    /* read size and type tables into buffer */
+    sf_index = reopen_streamfile(sf, total_frames*0x04 + total_frames*0x01);
+    if (!sf_index) goto fail;
+
+    /* read frames and sum all samples, since some codecs are VBR */
+    size_offset = 0x68;
+    type_offset = size_offset + total_frames*0x04;
+    data_offset = type_offset + total_frames*0x01 + trees_sizes;
+    for (i=0; i < total_frames; i++) {
+        uint32_t frame_size = read_u32le(size_offset,sf_index) & 0xFFFFFFFC; /* last 2 bits are keyframe flags */
+        uint8_t  frame_type = read_u8   (type_offset,sf_index); /* 0: has palette, 1..7: has stream N) */
+        off_t offset = data_offset;
+        
+        /* skip palette */
+        if (frame_type & (1<<0)) {
+            uint8_t palette_size = read_u8(offset,sf);
+            offset += palette_size * 4;
+        }
+
+        /* read target audio packet and ignore rest (though probably all streams are the same) */
+        for (j = 0; j < 7; j++) {
+            uint32_t audio_size;
+            
+            /* check if stream N exists in this frame (supposedly streams can be go in separate frames) */
+            if ( !(frame_type & (1<<(j+1))) )
+                continue;
+
+            audio_size = read_u32le(offset,sf);
+            
+            if (j == target_stream) {
+                
+                /* resulting PCM bytes to samples */
+                if (stream_flags & SMK_AUDIO_PACKED) { /* Smacker and maybe Bink codecs */
+                    uint32_t unpacked_size = read_u32le(offset+0x04,sf);
+                    num_samples += unpacked_size / (0x02 * channel_count);
+                }
+                else if (stream_flags & SMK_AUDIO_16BITS) { /* PCM16 */
+                    num_samples += (audio_size - 0x04) / (0x02 * channel_count);
+                }
+                else { /* PCM8 */
+                    num_samples += (audio_size - 0x04) / (0x01 * channel_count);
+                }
+            }
+
+            stream_size += audio_size;
+            offset += audio_size;
+        }
+        
+        /* rest is video packet (size = offset - data_offset) */
+
+        size_offset += 0x04;
+        type_offset += 0x01;
+        data_offset += frame_size;
+    }
+
+    if (out_total_subsongs) *out_total_subsongs = total_subsongs;
+    if (out_stream_size)    *out_stream_size = stream_size;
+    if (out_sample_rate)    *out_sample_rate = sample_rate;
+    if (out_channel_count)  *out_channel_count = channel_count;
+    if (out_num_samples)    *out_num_samples = num_samples;
+
+    close_streamfile(sf_index);
+    return 1;
+
+fail:
+    close_streamfile(sf_index);
+    return 0;
+}

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -485,6 +485,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_awb,
     init_vgmstream_acb,
     init_vgmstream_rad,
+    init_vgmstream_smk,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -732,6 +732,7 @@ typedef enum {
     meta_9TAV,
     meta_BWAV,
     meta_RAD,
+    meta_SMACKER,
 
 } meta_t;
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -1237,6 +1237,9 @@ typedef struct {
     // Seeking is not ideal, so rollback is necessary
     int samplesToDiscard;
 
+    // Flags for special seeking in faulty formats
+    int force_seek;
+    int bad_init;
 
 } ffmpeg_codec_data;
 #endif


### PR DESCRIPTION
- Fix .switch_audio and .sx extensions
- Add extensionless AIFC [Doom (3DO)]
- Add extensionless .dsp [Tony Hawk's Downhill Jam (Wii)]
- Fix some Wwise .wav and tweak size checks [Tony Hawk: Shred (Wii)]
- Fix some .s14
- Fix FFmpeg formats that can't seek
- Add .smk Smacker video [Starcraft (PC)]
