### PR TITLE
ogg msadpcm xa

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -18,7 +18,7 @@ ifeq ($(TARGET_OS),Windows_NT)
   CFLAGS += -DWIN32
 endif
 
-CFLAGS += -Wall -Werror=format-security -Wdeclaration-after-statement -Wvla -O3 -DVAR_ARRAYS -I../ext_includes $(EXTRA_CFLAGS)
+CFLAGS += -ffast-math -O3 -Wall -Werror=format-security -Wdeclaration-after-statement -Wvla -DVAR_ARRAYS -I../ext_includes $(EXTRA_CFLAGS)
 LDFLAGS += -L../src -L../ext_libs -lvgmstream $(EXTRA_LDFLAGS) -lm
 TARGET_EXT_LIBS = 
 

--- a/cli/vgmstream_cli.c
+++ b/cli/vgmstream_cli.c
@@ -283,13 +283,13 @@ static void apply_config(VGMSTREAM * vgmstream, cli_config *cfg) {
 
     /* honor suggested config, if any (defined order matters)
      * note that ignore_fade and play_forever should take priority */
-    if (vgmstream->config_loop_count) {
+    if (vgmstream->config_loop_count > 0.0) {
         cfg->loop_count = vgmstream->config_loop_count;
     }
-    if (vgmstream->config_fade_delay) {
+    if (vgmstream->config_fade_delay > 0.0) {
         cfg->fade_delay = vgmstream->config_fade_delay;
     }
-    if (vgmstream->config_fade_time) {
+    if (vgmstream->config_fade_time > 0.0) {
         cfg->fade_time = vgmstream->config_fade_time;
     }
     if (vgmstream->config_force_loop) {

--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -49,7 +49,7 @@ The following can be used in place of `(value)` for `(key) = (value)` commands.
   * `$1|2|3|4`: value has size of 8/16/24/32 bit (optional, defaults to 4)
   * Example: `@0x10:BE$2` means `get big endian 16b value at 0x10`
 - `(field)`: uses current value of some fields. Accepted strings:
-  - `interleave, interleave_last, channels, sample_rate, start_offset, data_size, num_samples, loop_start_sample,  loop_end_sample, subsong_count, subsong_offset`
+  - `interleave, interleave_last, channels, sample_rate, start_offset, data_size, num_samples, loop_start_sample,  loop_end_sample, subsong_count, subsong_offset, subfile_offset, subfile_size, name_valueX`
 - `(other)`: other special values for certain keys, described per key
 
 

--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -25,7 +25,7 @@ sounds/file#12
 
 
 ### Segments mode
-Some games clumsily loop audio by using multiple full file "segments", so you can play separate intro + loop files together as a single track. Channel number must be equal, mixing sample rates is ok (uses first).
+Some games clumsily loop audio by using multiple full file "segments", so you can play separate intro + loop files together as a single track.
  
 **Ratchet & Clank (PS2)**: *bgm01.txtp*
 ```
@@ -57,6 +57,8 @@ loop_start_segment = 2
 loop_end_segment = 3
 loop_mode = keep    # loops in 2nd file's loop_start to 3rd file's loop_end
 ```
+Mixing sample rates is ok (uses first) but channel number must be equal for all files. You can use mixing (explained later) to join segments of different channels though.
+
 
 ### Layers mode
 Some games layer channels or dynamic parts that must play at the same time, for example main melody + vocal track.

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -128,6 +128,7 @@ void decode_msadpcm_stereo(VGMSTREAM * vgmstream, sample_t * outbuf, int32_t fir
 void decode_msadpcm_mono(VGMSTREAM * vgmstream, sample_t * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);
 void decode_msadpcm_ck(VGMSTREAM * vgmstream, sample_t * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);
 long msadpcm_bytes_to_samples(long bytes, int block_size, int channels);
+int msadpcm_check_coefs(STREAMFILE *sf, off_t offset);
 
 /* yamaha_decoder */
 void decode_aica(VGMSTREAMCHANNEL * stream, sample_t * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel, int is_stereo);

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -212,10 +212,17 @@ int test_hca_key(hca_codec_data * data, unsigned long long keycode);
 
 #ifdef VGM_USE_VORBIS
 /* ogg_vorbis_decoder */
-void decode_ogg_vorbis(ogg_vorbis_codec_data * data, sample_t * outbuf, int32_t samples_to_do, int channels);
+ogg_vorbis_codec_data* init_ogg_vorbis(STREAMFILE *sf, off_t start, off_t size, ogg_vorbis_io *io);
+void decode_ogg_vorbis(ogg_vorbis_codec_data *data, sample_t *outbuf, int32_t samples_to_do, int channels);
 void reset_ogg_vorbis(VGMSTREAM *vgmstream);
 void seek_ogg_vorbis(VGMSTREAM *vgmstream, int32_t num_sample);
 void free_ogg_vorbis(ogg_vorbis_codec_data *data);
+
+int ogg_vorbis_get_comment(ogg_vorbis_codec_data *data, const char **comment);
+void ogg_vorbis_get_info(ogg_vorbis_codec_data *data, int *p_channels, int *p_sample_rate);
+void ogg_vorbis_get_samples(ogg_vorbis_codec_data *data, int *p_samples);
+void ogg_vorbis_set_disable_reordering(ogg_vorbis_codec_data *data, int set);
+STREAMFILE* ogg_vorbis_get_streamfile(ogg_vorbis_codec_data *data);
 
 /* vorbis_custom_decoder */
 vorbis_custom_codec_data *init_vorbis_custom(STREAMFILE *streamfile, off_t start_offset, vorbis_custom_t type, vorbis_custom_config * config);

--- a/src/coding/coding_utils.c
+++ b/src/coding/coding_utils.c
@@ -1160,25 +1160,12 @@ int w_bits(vgm_bitstream * ob, int num_bits, uint32_t value) {
 /* ******************************************** */
 
 STREAMFILE* setup_subfile_streamfile(STREAMFILE *sf, off_t subfile_offset, size_t subfile_size, const char* extension) {
-    STREAMFILE *temp_sf = NULL, *new_sf = NULL;
+    STREAMFILE *new_sf = NULL;
 
     new_sf = open_wrap_streamfile(sf);
-    if (!new_sf) goto fail;
-    temp_sf = new_sf;
-
-    new_sf = open_clamp_streamfile(temp_sf, subfile_offset, subfile_size);
-    if (!new_sf) goto fail;
-    temp_sf = new_sf;
-
+    new_sf = open_clamp_streamfile_f(new_sf, subfile_offset, subfile_size);
     if (extension) {
-        new_sf = open_fakename_streamfile(temp_sf, NULL, extension);
-        if (!new_sf) goto fail;
-        temp_sf = new_sf;
+        new_sf = open_fakename_streamfile_f(new_sf, NULL, extension);
     }
-
-    return temp_sf;
-
-fail:
-    close_streamfile(temp_sf);
-    return NULL;
+    return new_sf;
 }

--- a/src/coding/ogg_vorbis_decoder.c
+++ b/src/coding/ogg_vorbis_decoder.c
@@ -5,21 +5,183 @@
 #ifdef VGM_USE_VORBIS
 #include <vorbis/vorbisfile.h>
 
+#define OGG_DEFAULT_BITSTREAM 0
 
-static void pcm_convert_float_to_16(int channels, sample_t * outbuf, int samples_to_do, float ** pcm, int disable_ordering);
+/* opaque struct */
+struct ogg_vorbis_codec_data {
+    OggVorbis_File ogg_vorbis_file;
+    int ovf_init;
+    int bitstream;
+    int disable_reordering; /* Xiph Ogg must reorder channels on output, but some pre-ordered games don't need it */
+
+    ogg_vorbis_io io;
+    vorbis_comment *comment;
+    int comment_number;
+    vorbis_info *info;
+};
 
 
-void decode_ogg_vorbis(ogg_vorbis_codec_data * data, sample_t * outbuf, int32_t samples_to_do, int channels) {
+static void pcm_convert_float_to_16(int channels, sample_t *outbuf, int samples_to_do, float **pcm, int disable_ordering);
+
+static size_t ov_read_func(void *ptr, size_t size, size_t nmemb, void *datasource);
+static int ov_seek_func(void *datasource, ogg_int64_t offset, int whence);
+static long ov_tell_func(void *datasource);
+static int ov_close_func(void *datasource);
+
+
+ogg_vorbis_codec_data* init_ogg_vorbis(STREAMFILE *sf, off_t start, off_t size, ogg_vorbis_io *io) {
+    ogg_vorbis_codec_data *data = NULL;
+    ov_callbacks callbacks = {0};
+
+    //todo clean up
+
+    callbacks.read_func = ov_read_func;
+    callbacks.seek_func = ov_seek_func;
+    callbacks.close_func = ov_close_func;
+    callbacks.tell_func = ov_tell_func;
+
+    /* test if this is a proper Ogg Vorbis file, with the current (from init_x) STREAMFILE
+     * (quick test without having to malloc first, though if one invoked this it'll probably success) */
+    {
+        OggVorbis_File temp_ovf = {0};
+        ogg_vorbis_io temp_io = {0};
+
+        temp_io.streamfile = sf;
+
+        temp_io.start = start;
+        temp_io.offset = 0;
+        temp_io.size = size;
+
+        if (io != NULL) {
+            temp_io.decryption_callback = io->decryption_callback;
+            temp_io.scd_xor = io->scd_xor;
+            temp_io.scd_xor_length = io->scd_xor_length;
+            temp_io.xor_value = io->xor_value;
+        }
+
+        /* open the ogg vorbis file for testing */
+        if (ov_test_callbacks(&temp_io, &temp_ovf, NULL, 0, callbacks))
+            goto fail;
+
+        /* we have to close this as it has the init_vgmstream meta-reading STREAMFILE */
+        ov_clear(&temp_ovf);
+    }
+
+    /* proceed to init codec_data and reopen a STREAMFILE for this codec */
+    {
+        data = calloc(1,sizeof(ogg_vorbis_codec_data));
+        if (!data) goto fail;
+
+        data->io.streamfile = reopen_streamfile(sf, 0);
+        if (!data->io.streamfile) goto fail;
+
+        data->io.start = start;
+        data->io.offset = 0;
+        data->io.size = size;
+
+        if (io != NULL) {
+            data->io.decryption_callback = io->decryption_callback;
+            data->io.scd_xor = io->scd_xor;
+            data->io.scd_xor_length = io->scd_xor_length;
+            data->io.xor_value = io->xor_value;
+        }
+
+        /* open the ogg vorbis file for real */
+        if (ov_open_callbacks(&data->io, &data->ogg_vorbis_file, NULL, 0, callbacks))
+            goto fail;
+        data->ovf_init = 1;
+    }
+
+    //todo could set bitstreams as subsongs?
+    /* get info from bitstream */
+    data->bitstream = OGG_DEFAULT_BITSTREAM;
+
+    data->comment = ov_comment(&data->ogg_vorbis_file, data->bitstream);
+    data->info = ov_info(&data->ogg_vorbis_file, data->bitstream);
+
+    return data;
+fail:
+    free_ogg_vorbis(data);
+    return NULL;
+}
+
+static size_t ov_read_func(void *ptr, size_t size, size_t nmemb, void *datasource) {
+    ogg_vorbis_io *io = datasource;
+    size_t bytes_read, items_read;
+
+    off_t real_offset = io->start + io->offset;
+    size_t max_bytes = size * nmemb;
+
+    /* clamp for virtual filesize */
+    if (max_bytes > io->size - io->offset)
+        max_bytes = io->size - io->offset;
+
+    bytes_read = read_streamfile(ptr, real_offset, max_bytes, io->streamfile);
+    items_read = bytes_read / size;
+
+    /* may be encrypted */
+    if (io->decryption_callback) {
+        io->decryption_callback(ptr, size, items_read, io);
+    }
+
+    io->offset += items_read * size;
+
+    return items_read;
+}
+
+static int ov_seek_func(void *datasource, ogg_int64_t offset, int whence) {
+    ogg_vorbis_io *io = datasource;
+    ogg_int64_t base_offset, new_offset;
+
+    switch (whence) {
+        case SEEK_SET:
+            base_offset = 0;
+            break;
+        case SEEK_CUR:
+            base_offset = io->offset;
+            break;
+        case SEEK_END:
+            base_offset = io->size;
+            break;
+        default:
+            return -1;
+            break;
+    }
+
+
+    new_offset = base_offset + offset;
+    if (new_offset < 0 || new_offset > io->size) {
+        return -1; /* *must* return -1 if stream is unseekable */
+    } else {
+        io->offset = new_offset;
+        return 0;
+    }
+}
+
+static long ov_tell_func(void *datasource) {
+    ogg_vorbis_io *io = datasource;
+    return io->offset;
+}
+
+static int ov_close_func(void *datasource) {
+    /* needed as setting ov_close_func in ov_callbacks to NULL doesn't seem to work
+     * (closing the streamfile is done in free_ogg_vorbis) */
+    return 0;
+}
+
+/* ********************************************** */
+
+void decode_ogg_vorbis(ogg_vorbis_codec_data *data, sample_t *outbuf, int32_t samples_to_do, int channels) {
     int samples_done = 0;
     long rc;
     float **pcm_channels; /* pointer to Xiph's double array buffer */
 
     while (samples_done < samples_to_do) {
         rc = ov_read_float(
-                &data->ogg_vorbis_file, /* context */
-                &pcm_channels, /* buffer pointer */
-                (samples_to_do - samples_done), /* samples to produce */
-                &data->bitstream); /* bitstream*/
+                &data->ogg_vorbis_file,             /* context */
+                &pcm_channels,                      /* buffer pointer */
+                (samples_to_do - samples_done),     /* samples to produce */
+                &data->bitstream);                  /* bitstream */
         if (rc <= 0) goto fail; /* rc is samples done */
 
         pcm_convert_float_to_16(channels, outbuf, rc, pcm_channels, data->disable_reordering);
@@ -32,13 +194,13 @@ void decode_ogg_vorbis(ogg_vorbis_codec_data * data, sample_t * outbuf, int32_t 
         /* we use ov_read_float as to reuse the xiph's buffer for easier remapping,
          * but seems ov_read is slightly faster due to optimized (asm) float-to-int. */
         rc = ov_read(
-                &data->ogg_vorbis_file, /* context */
-                (char *)(outbuf), /* buffer */
+                &data->ogg_vorbis_file,             /* context */
+                (char *)(outbuf),                   /* buffer */
                 (samples_to_do - samples_done) * sizeof(sample_t) * channels, /* length in bytes */
-                0, /* pcm endianness */
-                sizeof(sample), /* pcm size */
-                1, /* pcm signedness */
-                &data->bitstream); /* bitstream */
+                0,                                  /* pcm endianness */
+                sizeof(sample),                     /* pcm size */
+                1,                                  /* pcm signedness */
+                &data->bitstream);                  /* bitstream */
         if (rc <= 0) goto fail; /* rc is bytes done (for all channels) */
 
         swap_samples_le(outbuf, rc / sizeof(sample_t)); /* endianness is a bit weird with ov_read though */
@@ -56,7 +218,7 @@ fail:
 
 /* vorbis encodes channels in non-standard order, so we remap during conversion to fix this oddity.
  * (feels a bit weird as one would think you could leave as-is and set the player's output
- * order, but that isn't possible and remapping is what FFmpeg and every other plugin do). */
+ * order, but that isn't possible and remapping is what FFmpeg and every other plugin does). */
 static const int xiph_channel_map[8][8] = {
     { 0 },                          /* 1ch: FC > same */
     { 0, 1 },                       /* 2ch: FL FR > same */
@@ -115,10 +277,61 @@ void seek_ogg_vorbis(VGMSTREAM *vgmstream, int32_t num_sample) {
 void free_ogg_vorbis(ogg_vorbis_codec_data *data) {
     if (!data) return;
 
-    ov_clear(&data->ogg_vorbis_file);
+    if (data->ovf_init)
+        ov_clear(&data->ogg_vorbis_file);
 
-    close_streamfile(data->ov_streamfile.streamfile);
+    close_streamfile(data->io.streamfile);
     free(data);
+}
+
+/* ********************************************** */
+
+int ogg_vorbis_get_comment(ogg_vorbis_codec_data *data, const char **comment) {
+    if (!data) return 0;
+
+    /* dumb reset */
+    if (comment == NULL) {
+        data->comment_number = 0;
+        return 1;
+    }
+
+    if (data->comment_number >= data->comment->comments)
+        return 0;
+
+    *comment = data->comment->user_comments[data->comment_number];
+    data->comment_number++;
+    return 1;
+}
+
+void ogg_vorbis_get_info(ogg_vorbis_codec_data *data, int *p_channels, int *p_sample_rate) {
+    if (!data) {
+        if (p_channels) *p_channels = 0;
+        if (p_sample_rate) *p_sample_rate = 0;
+        return;
+    }
+
+    if (p_channels) *p_channels = data->info->channels;
+    if (p_sample_rate) *p_sample_rate = (int)data->info->rate;
+}
+
+void ogg_vorbis_get_samples(ogg_vorbis_codec_data *data, int *p_samples) {
+    if (!data) {
+        if (p_samples) *p_samples = 0;
+        return;
+    }
+
+    if (p_samples) *p_samples = ov_pcm_total(&data->ogg_vorbis_file,-1);
+}
+
+void ogg_vorbis_set_disable_reordering(ogg_vorbis_codec_data *data, int set) {
+    if (!data) return;
+
+    data->disable_reordering = set;
+}
+
+STREAMFILE* ogg_vorbis_get_streamfile(ogg_vorbis_codec_data *data) {
+    if (!data) return NULL;
+    return data->io.streamfile;
 }
 
 #endif

--- a/src/layout/blocked_xa.c
+++ b/src/layout/blocked_xa.c
@@ -5,31 +5,36 @@
 /* parse a CD-XA raw mode2/form2 sector */
 void block_update_xa(off_t block_offset, VGMSTREAM * vgmstream) {
     STREAMFILE* streamFile = vgmstream->ch[0].streamfile;
-    int i;
+    int i, is_audio;
     size_t block_samples;
-    uint8_t xa_submode;
+    uint8_t xa_target, xa_submode, config_target;
 
 
     /* XA mode2/form2 sector, size 0x930
      * 0x00: sync word
      * 0x0c: header = minute, second, sector, mode (always 0x02)
-     * 0x10: subheader = file, channel (substream marker), submode flags, xa header
+     * 0x10: subheader = file, channel, submode flags, xa header
      * 0x14: subheader again (for error correction)
      * 0x18: data
      * 0x918: unused
      * 0x92c: EDC/checksum or null
      * 0x930: end
+     * Sectors with no data may exist near other with data
      */
+    xa_target = (uint8_t)read_16bitBE(block_offset + 0x10, streamFile);
+    config_target = vgmstream->codec_config;
 
-    /* channel markers supposedly could be used to interleave streams, ex. audio languages within video
-     * (extractors may split .XA using channels?) */
-    VGM_ASSERT(block_offset + 0x930 < get_streamfile_size(streamFile) &&
-            (uint8_t)read_8bit(block_offset + 0x000 + 0x11,streamFile) !=
-            (uint8_t)read_8bit(block_offset + 0x930 + 0x11,streamFile),
-            "XA block: subchannel change at %x\n", (uint32_t)block_offset);
+    /* Sector subheader's file+channel markers are used to interleave streams (music/sfx/voices)
+     * by reading one target file+channel while ignoring the rest. This is needed to adjust
+     * CD drive spinning <> decoding speed (data is read faster otherwise, so can't have 2
+     * sectors of the same channel), Normally N channels = N streams (usually 8/16/32 depending
+     * on sample rate/stereo), though channels can be empty or contain video (like 7 or 15 video
+     * sectors + 1 audio frame). Normally interleaved channels use with the same file ID, but some
+     * games change ID too. Extractors deinterleave and split .xa using file + channel + EOF flags. */
+
 
     /* submode flag bits (typical audio value = 0x64 01100100)
-     * - 7 (0x80 10000000): end of file
+     * - 7 (0x80 10000000): end of file (usually at data end, not per subheader's file)
      * - 6 (0x40 01000000): real time mode
      * - 5 (0x20 00100000): sector form (0=form1, 1=form2)
      * - 4 (0x10 00010000): trigger (for application)
@@ -37,11 +42,19 @@ void block_update_xa(off_t block_offset, VGMSTREAM * vgmstream) {
      * - 2 (0x04 00000100): audio sector
      * - 1 (0x02 00000010): video sector
      * - 0 (0x01 00000001): end of audio
+     * Empty sectors with no flags may exist interleaved with other with audio/data.
      */
     xa_submode = (uint8_t)read_8bit(block_offset + 0x12,streamFile);
 
     /* audio sector must set/not set certain flags, as per spec */
-    if (!(xa_submode & 0x08) && (xa_submode & 0x04) && !(xa_submode & 0x02)) {
+    is_audio = !(xa_submode & 0x08) && (xa_submode & 0x04) && !(xa_submode & 0x02);
+
+
+    if (xa_target != config_target) {
+        //;VGM_LOG("XA block: ignored block at %x\n", (uint32_t)block_offset);
+        block_samples = 0; /* not a target sector */
+    }
+    else if (is_audio) {
         if (xa_submode & 0x20) {
             /* form2 audio: size 0x900, 18 frames of size 0x80 with 8 subframes of 28 samples */
             block_samples = (28*8 / vgmstream->channels) * 18;

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -309,6 +309,10 @@
                     >
                 </File>
                 <File
+                    RelativePath=".\meta\riff_ogg_streamfile.h"
+                    >
+                </File>
+                <File
                     RelativePath=".\meta\sfh_streamfile.h"
                     >
                 </File>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -119,6 +119,7 @@
     <ClInclude Include="meta\mzrt_streamfile.h" />
     <ClInclude Include="meta\ogg_vorbis_streamfile.h" />
     <ClInclude Include="meta\opus_interleave_streamfile.h" />
+    <ClInclude Include="meta\riff_ogg_streamfile.h" />
     <ClInclude Include="meta\sfh_streamfile.h" />
     <ClInclude Include="meta\sqex_scd_streamfile.h" />
     <ClInclude Include="meta\sqex_sead_streamfile.h" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -128,6 +128,9 @@
     <ClInclude Include="meta\xavs_streamfile.h">
       <Filter>meta\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="meta\riff_ogg_streamfile.h">
+      <Filter>meta\Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="meta\sfh_streamfile.h">
       <Filter>meta\Header Files</Filter>
     </ClInclude>

--- a/src/meta/2dx9.c
+++ b/src/meta/2dx9.c
@@ -1,5 +1,5 @@
 #include "meta.h"
-#include "../util.h"
+#include "../coding/coding.h"
 
 /* 2DX9 - from Konami arcade games [beatmaniaIIDX16: EMPRESS (AC), BeatStream (AC), REFLEC BEAT (AC)] */
 VGMSTREAM * init_vgmstream_2dx9(STREAMFILE *streamFile) {
@@ -38,7 +38,9 @@ VGMSTREAM * init_vgmstream_2dx9(STREAMFILE *streamFile) {
     vgmstream->coding_type = coding_MSADPCM;
     vgmstream->layout_type = layout_none;
     vgmstream->frame_size  = read_16bitLE(0x38,streamFile);
-    
+    if (!msadpcm_check_coefs(streamFile, 0x40))
+        goto fail;
+
     if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
         goto fail;
     return vgmstream;

--- a/src/meta/2dx9.c
+++ b/src/meta/2dx9.c
@@ -1,69 +1,49 @@
 #include "meta.h"
 #include "../util.h"
 
-/* 2DX9 (found in beatmaniaIIDX16 - EMPRESS (Arcade) */
+/* 2DX9 - from Konami arcade games [beatmaniaIIDX16: EMPRESS (AC), BeatStream (AC), REFLEC BEAT (AC)] */
 VGMSTREAM * init_vgmstream_2dx9(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
-    char filename[PATH_LIMIT];
     off_t start_offset;
+    int channel_count, loop_flag;
 
-	int loop_flag;
-	int channel_count;
 
-    /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("2dx9",filename_extension(filename))) goto fail;
+    /* checks */
+    if (!check_extensions(streamFile, "2dx9"))
+        goto fail;
 
     /* check header */
-    if (read_32bitBE(0x0,streamFile) != 0x32445839) /* 2DX9 */
-		goto fail;
-	if (read_32bitBE(0x18,streamFile) != 0x52494646) /* RIFF */
-		goto fail;
-	if (read_32bitBE(0x20,streamFile) != 0x57415645) /* WAVE */
-		goto fail;
-	if (read_32bitBE(0x24,streamFile) != 0x666D7420) /* fmt */
-		goto fail;
+    if (read_32bitBE(0x00,streamFile) != 0x32445839) /* 2DX9 */
+        goto fail;
+    if (read_32bitBE(0x18,streamFile) != 0x52494646) /* RIFF */
+        goto fail;
+    if (read_32bitBE(0x20,streamFile) != 0x57415645) /* WAVE */
+        goto fail;
+    if (read_32bitBE(0x24,streamFile) != 0x666D7420) /* fmt */
+        goto fail;
     if (read_32bitBE(0x6a,streamFile) != 0x64617461) /* data */
-		goto fail;
+        goto fail;
 
     loop_flag = 0;
     channel_count = read_16bitLE(0x2e,streamFile);
+    start_offset = 0x72;
     
-	/* build the VGMSTREAM */
+    /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
-	/* fill in the vital statistics */
-    start_offset = 0x72;
-	vgmstream->channels = channel_count;
-    vgmstream->sample_rate = read_32bitLE(0x30,streamFile);
-    vgmstream->coding_type = coding_MSADPCM;
-    vgmstream->num_samples = read_32bitLE(0x66,streamFile);
-    vgmstream->layout_type = layout_none;
-	vgmstream->interleave_block_size = read_16bitLE(0x38,streamFile);
     vgmstream->meta_type = meta_2DX9;
-
-    /* open the file for reading */
-    {
-        int i;
-        STREAMFILE * file;
-        file = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-        if (!file) goto fail;
-        for (i=0;i<channel_count;i++) {
-            vgmstream->ch[i].streamfile = file;
-
-            vgmstream->ch[i].channel_start_offset=
-                vgmstream->ch[i].offset=start_offset+
-                vgmstream->interleave_block_size*i;
-
-        }
-    }
-
+    vgmstream->sample_rate = read_32bitLE(0x30,streamFile);
+    vgmstream->num_samples = read_32bitLE(0x66,streamFile);
+    vgmstream->coding_type = coding_MSADPCM;
+    vgmstream->layout_type = layout_none;
+    vgmstream->frame_size  = read_16bitLE(0x38,streamFile);
     
-	return vgmstream;
+    if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
+        goto fail;
+    return vgmstream;
 
 fail:
-    /* clean up anything we may have opened */
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/acb.c
+++ b/src/meta/acb.c
@@ -70,24 +70,15 @@ fail:
 
 /* ************************************** */
 
+//todo maybe use reopen sf? since internal buffer is going to be read
 #define ACB_TABLE_BUFFER_SIZE 0x4000
 
-STREAMFILE* setup_acb_streamfile(STREAMFILE *streamFile, size_t buffer_size) {
-    STREAMFILE *temp_streamFile = NULL, *new_streamFile = NULL;
+STREAMFILE* setup_acb_streamfile(STREAMFILE *sf, size_t buffer_size) {
+    STREAMFILE *new_sf = NULL;
 
-    new_streamFile = open_wrap_streamfile(streamFile);
-    if (!new_streamFile) goto fail;
-    temp_streamFile = new_streamFile;
-
-    new_streamFile = open_buffer_streamfile(temp_streamFile, buffer_size);
-    if (!new_streamFile) goto fail;
-    temp_streamFile = new_streamFile;
-
-    return temp_streamFile;
-
-fail:
-    close_streamfile(temp_streamFile);
-    return NULL;
+    new_sf = open_wrap_streamfile(sf);
+    new_sf = open_buffer_streamfile_f(new_sf, buffer_size);
+    return new_sf;
 }
 
 

--- a/src/meta/aix.c
+++ b/src/meta/aix.c
@@ -110,7 +110,7 @@ static VGMSTREAM *build_layered_vgmstream(STREAMFILE *streamFile, off_t segment_
     VGMSTREAM *vgmstream = NULL;
     layered_layout_data* data = NULL;
     int i;
-    STREAMFILE* temp_streamFile = NULL;
+    STREAMFILE* temp_sf = NULL;
 
 
     /* build layers */
@@ -119,17 +119,17 @@ static VGMSTREAM *build_layered_vgmstream(STREAMFILE *streamFile, off_t segment_
 
     for (i = 0; i < layer_count; i++) {
         /* build the layer STREAMFILE */
-        temp_streamFile = setup_aix_streamfile(streamFile, segment_offset, segment_size, i, "adx");
-        if (!temp_streamFile) goto fail;
+        temp_sf = setup_aix_streamfile(streamFile, segment_offset, segment_size, i, "adx");
+        if (!temp_sf) goto fail;
 
         /* build the sub-VGMSTREAM */
-        data->layers[i] = init_vgmstream_adx(temp_streamFile);
+        data->layers[i] = init_vgmstream_adx(temp_sf);
         if (!data->layers[i]) goto fail;
 
-        data->layers[i]->stream_size = get_streamfile_size(temp_streamFile);
+        data->layers[i]->stream_size = get_streamfile_size(temp_sf);
 
-        close_streamfile(temp_streamFile);
-        temp_streamFile = NULL;
+        close_streamfile(temp_sf);
+        temp_sf = NULL;
     }
 
     if (!setup_layout_layered(data))
@@ -145,7 +145,7 @@ static VGMSTREAM *build_layered_vgmstream(STREAMFILE *streamFile, off_t segment_
 fail:
     if (!vgmstream) free_layout_layered(data);
     close_vgmstream(vgmstream);
-    close_streamfile(temp_streamFile);
+    close_streamfile(temp_sf);
     return NULL;
 }
 

--- a/src/meta/aix_streamfile.h
+++ b/src/meta/aix_streamfile.h
@@ -112,40 +112,22 @@ static size_t aix_io_size(STREAMFILE *streamfile, aix_io_data* data) {
 }
 
 /* Handles deinterleaving of AIX blocked layer streams */
-static STREAMFILE* setup_aix_streamfile(STREAMFILE *streamFile, off_t stream_offset, size_t stream_size, int layer_number, const char* extension) {
-    STREAMFILE *temp_streamFile = NULL, *new_streamFile = NULL;
+static STREAMFILE* setup_aix_streamfile(STREAMFILE *sf, off_t stream_offset, size_t stream_size, int layer_number, const char* extension) {
+    STREAMFILE *new_sf = NULL;
     aix_io_data io_data = {0};
-    size_t io_data_size = sizeof(aix_io_data);
 
     io_data.stream_offset = stream_offset;
     io_data.stream_size = stream_size;
     io_data.layer_number = layer_number;
     io_data.logical_offset = -1; /* force reset */
 
-    /* setup subfile */
-    new_streamFile = open_wrap_streamfile(streamFile);
-    if (!new_streamFile) goto fail;
-    temp_streamFile = new_streamFile;
-
-    new_streamFile = open_io_streamfile(new_streamFile, &io_data,io_data_size, aix_io_read,aix_io_size);
-    if (!new_streamFile) goto fail;
-    temp_streamFile = new_streamFile;
-
-    new_streamFile = open_buffer_streamfile(new_streamFile,0);
-    if (!new_streamFile) goto fail;
-    temp_streamFile = new_streamFile;
-
+    new_sf = open_wrap_streamfile(sf);
+    new_sf = open_io_streamfile_f(new_sf, &io_data, sizeof(aix_io_data), aix_io_read, aix_io_size);
+    new_sf = open_buffer_streamfile_f(new_sf, 0);
     if (extension) {
-        new_streamFile = open_fakename_streamfile(temp_streamFile, NULL,extension);
-        if (!new_streamFile) goto fail;
-        temp_streamFile = new_streamFile;
+        new_sf = open_fakename_streamfile_f(new_sf, NULL, extension);
     }
-
-    return temp_streamFile;
-
-fail:
-    close_streamfile(temp_streamFile);
-    return NULL;
+    return new_sf;
 }
 
 #endif /* _AIX_STREAMFILE_H_ */

--- a/src/meta/akb.c
+++ b/src/meta/akb.c
@@ -91,7 +91,7 @@ VGMSTREAM * init_vgmstream_akb(STREAMFILE *streamFile) {
         case 0x02: { /* MSADPCM [Dragon Quest II (iOS) sfx] */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = read_16bitLE(extradata_offset + 0x02,streamFile);
+            vgmstream->frame_size = read_16bitLE(extradata_offset + 0x02,streamFile);
 
             /* adjusted samples; bigger or smaller than base samples, akb lib uses these fields instead
              * (base samples may have more than possible and read over file size otherwise, very strange)
@@ -277,7 +277,7 @@ VGMSTREAM * init_vgmstream_akb2(STREAMFILE *streamFile) {
         case 0x02: { /* MSADPCM [The Irregular at Magic High School Lost Zero (Android)] */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = read_16bitLE(extradata_offset + 0x02, streamFile);
+            vgmstream->frame_size = read_16bitLE(extradata_offset + 0x02, streamFile);
 
             /* adjusted samples; bigger or smaller than base samples, akb lib uses these fields instead
              * (base samples may have more than possible and read over file size otherwise, very strange)

--- a/src/meta/ck.c
+++ b/src/meta/ck.c
@@ -56,7 +56,7 @@ VGMSTREAM * init_vgmstream_cks(STREAMFILE *streamFile) {
             break;
         case 0x02: /* adpcm [Part Time UFO (Android), Mega Man 1-6 (Android)] */
             vgmstream->coding_type = coding_MSADPCM_ck;
-            /* frame_size is always 0x18 */
+            vgmstream->frame_size = block_size / channel_count; /* always 0x18 */
             break;
         default:
             goto fail;

--- a/src/meta/dec.c
+++ b/src/meta/dec.c
@@ -122,10 +122,10 @@ static int get_falcom_looping(STREAMFILE *streamFile, int *out_loop_start, int *
     while (txt_offset < get_streamfile_size(streamText)) {
         char line[TXT_LINE_MAX];
         char name[TXT_LINE_MAX];
-        int ok, line_done, loop, bytes_read;
+        int ok, line_ok, loop, bytes_read;
 
-        bytes_read = get_streamfile_text_line(TXT_LINE_MAX,line, txt_offset,streamText, &line_done);
-        if (!line_done) goto end;
+        bytes_read = read_line(line, TXT_LINE_MAX, txt_offset, streamText, &line_ok);
+        if (!line_ok) goto end;
 
         txt_offset += bytes_read;
 

--- a/src/meta/dec.c
+++ b/src/meta/dec.c
@@ -76,7 +76,7 @@ VGMSTREAM * init_vgmstream_dec(STREAMFILE *streamFile) {
     vgmstream->loop_end_sample = loop_end;
 
     vgmstream->coding_type = coding_MSADPCM;
-    vgmstream->interleave_block_size = 0x800;
+    vgmstream->frame_size = 0x800;
     vgmstream->layout_type = layout_blocked_dec;
 
     if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )

--- a/src/meta/genh.c
+++ b/src/meta/genh.c
@@ -225,13 +225,15 @@ VGMSTREAM * init_vgmstream_genh(STREAMFILE *streamFile) {
             vgmstream->interleave_block_size = genh.interleave;
             vgmstream->layout_type = layout_none;
             break;
+
         case coding_MSADPCM:
             if (vgmstream->channels > 2) goto fail;
-            if (!genh.interleave) goto fail; /* creates garbage */
+            if (!genh.interleave) goto fail;
 
-            vgmstream->interleave_block_size = genh.interleave;
+            vgmstream->frame_size = genh.interleave;
             vgmstream->layout_type = layout_none;
             break;
+
         case coding_XBOX_IMA:
             if (genh.codec_mode == 1) { /* mono interleave */
                 coding = coding_XBOX_IMA_int;

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -128,7 +128,7 @@ typedef struct {
 
 } ogg_vorbis_meta_info_t;
 
-VGMSTREAM * init_vgmstream_ogg_vorbis_callbacks(STREAMFILE *streamFile, ov_callbacks *callbacks, off_t other_header_bytes, const ogg_vorbis_meta_info_t *ovmi);
+VGMSTREAM * init_vgmstream_ogg_vorbis_callbacks(STREAMFILE *streamFile, ov_callbacks *callbacks, off_t start, const ogg_vorbis_meta_info_t *ovmi);
 #endif
 
 VGMSTREAM * init_vgmstream_hca(STREAMFILE *streamFile);

--- a/src/meta/mzrt.c
+++ b/src/meta/mzrt.c
@@ -45,15 +45,22 @@ VGMSTREAM * init_vgmstream_mzrt(STREAMFILE *streamFile) {
             goto fail;
     }
 
-    /* skip fmt-extra data */
-    if (codec == 0x0002 || codec == 0x0166) {
+    /* skip MSADPCM data */
+    if (codec == 0x0002) {
+        if (!msadpcm_check_coefs(streamFile, start_offset + 0x02 + 0x02))
+            goto fail;
+
+        start_offset += 0x02 + read_16bitLE(start_offset, streamFile);
+    }
+
+    /* skip extra data */
+    if (codec == 0x0166) {
         start_offset += 0x02 + read_16bitLE(start_offset, streamFile);
     }
 
     /* skip unknown table */
     if (codec == 0x0000) {
         start_offset += 0x04 + read_32bitBE(start_offset, streamFile) * 0x04;
-
     }
 
     /* skip unknown table */
@@ -95,7 +102,7 @@ VGMSTREAM * init_vgmstream_mzrt(STREAMFILE *streamFile) {
             if (bps != 4) goto fail;
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = block_size;
+            vgmstream->frame_size = block_size;
             break;
 
 #ifdef VGM_USE_FFMPEG

--- a/src/meta/riff_ogg_streamfile.h
+++ b/src/meta/riff_ogg_streamfile.h
@@ -1,0 +1,130 @@
+#ifndef _RIFF_OGG_STREAMFILE_H_
+#define _RIFF_OGG_STREAMFILE_H_
+#include "../streamfile.h"
+
+#ifdef VGM_USE_VORBIS
+typedef struct {
+    off_t patch_offset;
+} riff_ogg_io_data;
+
+static size_t riff_ogg_io_read(STREAMFILE *streamfile, uint8_t *dest, off_t offset, size_t length, riff_ogg_io_data* data) {
+    size_t bytes_read = streamfile->read(streamfile, dest, offset, length);
+
+    /* has garbage init Oggs pages, patch bad flag */
+    if (data->patch_offset && data->patch_offset >= offset && data->patch_offset < offset + bytes_read) {
+        VGM_ASSERT(dest[data->patch_offset - offset] != 0x02, "RIFF Ogg: bad patch offset at %lx\n", data->patch_offset);
+        dest[data->patch_offset - offset] = 0x00;
+    }
+
+    return bytes_read;
+}
+
+static size_t ogg_get_page(uint8_t *buf, size_t bufsize, off_t offset, STREAMFILE *sf) {
+    size_t segments, bytes, page_size;
+    int i;
+
+    if (0x1b > bufsize) goto fail;
+    bytes = read_streamfile(buf, offset, 0x1b, sf);
+    if (bytes != 0x1b) goto fail;
+
+    segments = get_u8(buf + 0x1a);
+    if (0x1b + segments > bufsize) goto fail;
+
+    bytes = read_streamfile(buf + 0x1b, offset + 0x1b, segments, sf);
+    if (bytes != segments) goto fail;
+
+    page_size = 0x1b + segments;
+    for (i = 0; i < segments; i++) {
+        page_size += get_u8(buf + 0x1b + i);
+    }
+
+    return page_size;
+fail:
+    return 0;
+}
+
+/* patches Oggs with weirdness */
+static STREAMFILE* setup_riff_ogg_streamfile(STREAMFILE *sf, off_t start, size_t size) {
+    off_t patch_offset = 0;
+    size_t real_size = size;
+    uint8_t buf[0x1000];
+
+
+    /* initial page flag is repeated and causes glitches in decoders, find bad offset */
+    //todo callback could patch on-the-fly by analyzing all "OggS", but is problematic due to arbitrary offsets
+    {
+        off_t offset = start;
+        size_t page_size;
+        off_t offset_limit = start + size; /* usually in the first 0x3000 but can be +0x100000 */
+        //todo this doesn't seem to help much
+        STREAMFILE *temp_sf = reopen_streamfile(sf, 0x100); /* use small-ish sf to avoid reading the whole thing */
+
+        /* first page is ok */
+        page_size = ogg_get_page(buf, sizeof(buf), offset, temp_sf);
+        offset += page_size;
+
+        while (offset < offset_limit) {
+            page_size = ogg_get_page(buf, sizeof(buf), offset, temp_sf);
+            if (page_size == 0) break;
+
+            if (get_u32be(buf + 0x00) != 0x4f676753) /* "OggS" */
+                break;
+
+            if (get_u16be(buf + 0x04) == 0x0002) { /* start page flag */
+                //;VGM_ASSERT(patch_offset > 0, "RIFF Ogg: found multiple repeated start pages\n");
+                patch_offset = (offset - start) + 0x04 + 0x01; /* clamp'ed */
+                break;
+            }
+
+            offset += page_size;
+        }
+
+        close_streamfile(temp_sf);
+
+        if (patch_offset == 0)
+            return NULL;
+    }
+
+    /* has a bunch of padding(?) pages at the end with no data nor flag that confuse decoders, find actual end */
+    {
+        size_t chunk_size = sizeof(buf); /* not worth testing more */
+        size_t max_size = size;
+        size_t pos;
+        off_t read_offset = start + size - chunk_size;
+
+        pos = read_streamfile(buf, read_offset, chunk_size, sf);
+        if (read_offset < 0 || pos <= 0x1a) return NULL;
+
+        pos -= 0x1a; /* at least one OggS page */
+        while (pos > 0) {
+            if (get_u32be(buf + pos + 0x00) == 0x4f676753) { /* "OggS" */
+
+                if (get_u16be(buf + pos + 0x04) == 0x0004) { /* last page flag is ok */
+                    real_size = max_size;
+                    break;
+                }
+                else { /* last page flag is wrong */
+                    max_size = size - (chunk_size - pos); /* update size up to this page */
+                }
+            }
+            pos--;
+        }
+    }
+
+    /* actual custom streamfile init */
+    {
+        STREAMFILE *new_sf = NULL;
+        riff_ogg_io_data io_data = {0};
+
+        io_data.patch_offset = patch_offset;
+
+        new_sf = open_wrap_streamfile(sf);
+        new_sf = open_clamp_streamfile_f(new_sf, start, real_size);
+        new_sf = open_io_streamfile_f(new_sf, &io_data, sizeof(riff_ogg_io_data), riff_ogg_io_read, NULL);
+        return new_sf;
+    }
+}
+
+#endif /* VGM_USE_VORBIS */
+
+#endif /* _RIFF_OGG_STREAMFILE_H_ */

--- a/src/meta/sd9.c
+++ b/src/meta/sd9.c
@@ -1,17 +1,16 @@
 #include "meta.h"
-#include "../util.h"
+#include "../coding/coding.h"
 
-/* SD9 (found in beatmania IIDX Arcade games) */
+/* SD9 - from Konami arcade games [beatmania IIDX series (AC), BeatStream (AC)] */
 VGMSTREAM * init_vgmstream_sd9(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     off_t start_offset;
     int loop_flag, channel_count;
 
-    /* check extension */
+    /* checks */
     if (!check_extensions(streamFile, "sd9"))
         goto fail;
 
-    /* check header */
     if (read_32bitBE(0x0, streamFile) != 0x53443900) /* SD9 */
         goto fail;
     if (read_32bitBE(0x20, streamFile) != 0x52494646) /* RIFF */
@@ -30,27 +29,26 @@ VGMSTREAM * init_vgmstream_sd9(STREAMFILE *streamFile) {
     //loop_flag = (read_16bitLE(0x0e,streamFile)==0x1);
     loop_flag = read_32bitLE(0x18, streamFile); // use loop end
     channel_count = read_16bitLE(0x36, streamFile);
+    start_offset = 0x7a;
 
     /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channel_count, loop_flag);
     if (!vgmstream) goto fail;
 
-    /* fill in the vital statistics */
-    start_offset = 0x7a;
-    vgmstream->channels = channel_count;
     vgmstream->sample_rate = read_32bitLE(0x38, streamFile);
-    vgmstream->coding_type = coding_MSADPCM;
     vgmstream->num_samples = read_32bitLE(0x6e, streamFile);
     if (loop_flag) {
         vgmstream->loop_start_sample = read_32bitLE(0x14, streamFile) / 2 / channel_count;
         vgmstream->loop_end_sample = read_32bitLE(0x18, streamFile) / 2 / channel_count;
     }
 
+    vgmstream->coding_type = coding_MSADPCM;
     vgmstream->layout_type = layout_none;
-    vgmstream->interleave_block_size = read_16bitLE(0x40, streamFile);
+    vgmstream->frame_size = read_16bitLE(0x40, streamFile);
     vgmstream->meta_type = meta_SD9;
+    if (!msadpcm_check_coefs(streamFile, 0x48))
+        goto fail;
 
-    /* open the file for reading */
     if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
         goto fail;
     return vgmstream;

--- a/src/meta/sgxd.c
+++ b/src/meta/sgxd.c
@@ -112,6 +112,14 @@ VGMSTREAM * init_vgmstream_sgxd(STREAMFILE *streamFile) {
         read_string(vgmstream->stream_name,STREAM_NAME_SIZE, name_offset,streamHeader);
 
     switch (type) {
+#ifdef VGM_USE_FFMPEG
+        case 0x02:      /* Ogg Vorbis [Ni no Kuni: Wrath of the White Witch Remastered (PC)] (codec hijack?) */
+            vgmstream->codec_data = init_ogg_vorbis(streamFile, start_offset, stream_size, NULL);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_OGG_VORBIS;
+            vgmstream->layout_type = layout_none;
+            break;
+#endif
         case 0x03:      /* PS-ADPCM [Genji (PS3), Ape Escape Move (PS3)]*/
             vgmstream->coding_type = coding_PSX;
             vgmstream->layout_type = layout_interleave;

--- a/src/meta/sli.c
+++ b/src/meta/sli.c
@@ -53,39 +53,39 @@ VGMSTREAM * init_vgmstream_sli_ogg(STREAMFILE *streamFile) {
 
     /* find loop text */
     {
-        char linebuffer[PATH_LIMIT];
+        char line[PATH_LIMIT];
         size_t bytes_read;
         off_t sli_offset;
-        int done;
+        int line_ok;
 
         sli_offset = 0;
         while ((loop_start == -1 || loop_length == -1) && sli_offset < get_streamfile_size(streamFile)) {
             char *endptr, *foundptr;
 
-            bytes_read = get_streamfile_text_line(sizeof(linebuffer),linebuffer,sli_offset,streamFile,&done);
-            if (!done) goto fail;
+            bytes_read = read_line(line, sizeof(line), sli_offset, streamFile, &line_ok);
+            if (!line_ok) goto fail;
 
-            if (memcmp("LoopStart=",linebuffer,10)==0 && linebuffer[10] != '\0') {
-                loop_start = strtol(linebuffer+10,&endptr,10);
+            if (memcmp("LoopStart=",line,10)==0 && line[10] != '\0') {
+                loop_start = strtol(line+10,&endptr,10);
                 if (*endptr != '\0') {
                     loop_start = -1; /* if it didn't parse cleanly */
                 }
             }
-            else if (memcmp("LoopLength=",linebuffer,11)==0 && linebuffer[11] != '\0') {
-                loop_length = strtol(linebuffer+11,&endptr,10);
+            else if (memcmp("LoopLength=",line,11)==0 && line[11] != '\0') {
+                loop_length = strtol(line+11,&endptr,10);
                 if (*endptr != '\0') {
                     loop_length = -1; /* if it didn't parse cleanly */
                 }
             }
 
             /* a completely different format (2.0?), also with .sli extension and can be handled similarly */
-            if ((foundptr = strstr(linebuffer,"To=")) != NULL && isdigit(foundptr[3])) {
+            if ((foundptr = strstr(line,"To=")) != NULL && isdigit(foundptr[3])) {
                 loop_to = strtol(foundptr+3,&endptr,10);
                 if (*endptr != ';') {
                     loop_to = -1;
                 }
             }
-            if ((foundptr = strstr(linebuffer,"From=")) != NULL && isdigit(foundptr[5])) {
+            if ((foundptr = strstr(line,"From=")) != NULL && isdigit(foundptr[5])) {
                 loop_from = strtol(foundptr+5,&endptr,10);
                 if (*endptr != ';') {
                     loop_from = -1;

--- a/src/meta/smp.c
+++ b/src/meta/smp.c
@@ -74,11 +74,12 @@ VGMSTREAM * init_vgmstream_smp(STREAMFILE *streamFile) {
 
         case 0x04:
             if (bps != 4) goto fail;
-            /* 0x34: standard MSADPCM coef table */
+            if (!msadpcm_check_coefs(streamFile, 0x36))
+                goto fail;
 
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = 0x86*channel_count;
+            vgmstream->frame_size = 0x86*channel_count;
             break;
 
         case 0x06:

--- a/src/meta/spt_spd.c
+++ b/src/meta/spt_spd.c
@@ -1,109 +1,110 @@
 #include "meta.h"
-#include "../util.h"
+#include "../coding/coding.h"
 
-/* SPT+SPT
 
-   2008-11-27 - manakoAT : First try for splitted files...
-*/
-
+/* SPD+SPT - Nintendo bank (bgm or sfx) format [Bloodrayne (GC), 4x4 EVO 2 (GC), Table Tennis (Wii)] */
 VGMSTREAM * init_vgmstream_spt_spd(STREAMFILE *streamFile) {
-	  
-  VGMSTREAM * vgmstream = NULL;
-  STREAMFILE * streamFileSPT = NULL;
-  char filename[PATH_LIMIT];
-	char filenameSPT[PATH_LIMIT];
-	int channel_count;
-	int loop_flag;
-  int i;
+    VGMSTREAM *vgmstream = NULL;
+    STREAMFILE *sf_h = NULL;
+    int channel_count, loop_flag, sample_rate;
+    off_t header_offset, extra_offset, start_offset;
+    int32_t loop_start, loop_end, stream_start, stream_end;
+    size_t stream_size;
+    uint32_t flags;
+    int total_subsongs, target_subsong = streamFile->stream_index;
 
-  /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("spd",filename_extension(filename))) goto fail;
 
-  	strcpy(filenameSPT,filename);
-	  strcpy(filenameSPT+strlen(filenameSPT)-3,"spt");
-
-	  streamFileSPT = streamFile->open(streamFile,filenameSPT,STREAMFILE_DEFAULT_BUFFER_SIZE);
-    if (!streamFileSPT)
+    /* checks */
+    if (!check_extensions(streamFile, "spd"))
         goto fail;
-    
-    if (read_32bitBE(0x0,streamFileSPT) != 0x1) // make sure that it's not a container
+    sf_h = open_streamfile_by_ext(streamFile, "spt");
+    if (!sf_h) goto fail;
+
+    /* ignore alt .spt+spd [Spyro: Enter the Dragonfly (GC)] */
+    if (read_u16be(0x00, sf_h) != 0) /* always 0xA20C? */
         goto fail;
 
-	  channel_count = 1;
-	  loop_flag = (read_32bitBE(0x0C,streamFileSPT) == 0x2);
+    total_subsongs = read_s32be(0x00, sf_h);
+    if (target_subsong == 0) target_subsong = 1;
+    if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
+
+    header_offset = 0x04 + 0x1c * (target_subsong-1);
+    extra_offset  = 0x04 + 0x1c * total_subsongs + 0x2e * (target_subsong-1);
+
+    flags           = read_u32be(header_offset + 0x00, sf_h);
+    sample_rate     = read_s32be(header_offset + 0x04, sf_h);
+    loop_start      = read_s32be(header_offset + 0x08, sf_h);
+    loop_end        = read_s32be(header_offset + 0x0c, sf_h);
+    stream_end      = read_s32be(header_offset + 0x10, sf_h);
+    stream_start    = read_s32be(header_offset + 0x14, sf_h);
+    /* 0x18: null */
+
+    channel_count = 1;
+    loop_flag = (flags & 1);
+
 
     /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
-    /* fill in the vital statistics */
-	  vgmstream->channels = channel_count;
-	  vgmstream->sample_rate = read_32bitBE(0x08,streamFileSPT);
-
-	  switch ((read_32bitBE(0x4,streamFileSPT))) {
-		  case 0:
-      case 1:
-			  vgmstream->coding_type = coding_NGC_DSP;
-        vgmstream->num_samples=read_32bitBE(0x14,streamFileSPT)*14/16/channel_count;
-  	    if(loop_flag) {
-	  	  vgmstream->loop_start_sample = 0;
-		    vgmstream->loop_end_sample = read_32bitBE(0x14,streamFileSPT)*14/16/channel_count;
-        }
-      break;
-		  case 2:
-		    vgmstream->coding_type = coding_PCM16BE;
-        vgmstream->num_samples=read_32bitBE(0x14,streamFileSPT)/channel_count;
-       	if(loop_flag) {
-  	  	vgmstream->loop_start_sample = 0;
-	  	  vgmstream->loop_end_sample = read_32bitBE(0x14,streamFileSPT)/channel_count;
-        }
-			break;
-		    default:
-	        goto fail;
-    }
-
-  	if (channel_count == 1) {
-	  	  vgmstream->layout_type = layout_none;
-	  } else if (channel_count == 2) {
-		    vgmstream->layout_type = layout_interleave;
-		    vgmstream->interleave_block_size=(read_32bitBE(0x34,streamFileSPT)*channel_count)/2;
-    }
-
     vgmstream->meta_type = meta_SPT_SPD;
     vgmstream->allow_dual_stereo = 1;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->layout_type = layout_none;
 
-    /* open the file for reading */
-    {
-        for (i=0;i<channel_count;i++) {
-			/* Not sure, i'll put a fake value here for now */
-            vgmstream->ch[i].streamfile = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-            vgmstream->ch[i].offset = 0;
-            if (!vgmstream->ch[i].streamfile) goto fail;
-        }
-    }
+    vgmstream->num_streams = total_subsongs;
 
-
-    
-	if (vgmstream->coding_type == coding_NGC_DSP) {
-        int i;
-        for (i=0;i<16;i++) {
-            vgmstream->ch[0].adpcm_coef[i] = read_16bitBE(0x20+i*2,streamFileSPT);
-        }
-        if (vgmstream->channels == 2) {
-            for (i=0;i<16;i++) {
-                vgmstream->ch[1].adpcm_coef[i] = read_16bitBE(0x40+i*2,streamFileSPT);
+    switch(flags & (~1)) { /* bitflags */
+        case 0: /* common */
+            /* values in file nibbles? */
+            start_offset = (stream_start / 2 - 1);
+            stream_size = (stream_end / 2 + 1) - (stream_start / 2 - 1);
+            if (loop_flag) {
+                loop_start = (loop_start / 2 - 1) - start_offset;
+                loop_end = (loop_end / 2 + 1) - start_offset;
             }
-        }
+
+            vgmstream->coding_type = coding_NGC_DSP;
+            vgmstream->num_samples = dsp_bytes_to_samples(stream_size, channel_count);
+            if (loop_flag) {
+                vgmstream->loop_start_sample = dsp_bytes_to_samples(loop_start, channel_count);
+                vgmstream->loop_end_sample = dsp_bytes_to_samples(loop_end, channel_count);
+            }
+            dsp_read_coefs_be(vgmstream, sf_h, extra_offset + 0x00, 0x00);
+            dsp_read_hist_be (vgmstream, sf_h, extra_offset + 0x24, 0x00);
+            break;
+
+        case 2: /* rare [Monster Jam: Maximum Destruction (GC)] */
+            /* values in samples? */
+            start_offset = (stream_start * 2);
+            stream_size = (stream_end * 2) - (stream_start * 2);
+            if (loop_flag) {
+                loop_start = (loop_start * 2) - start_offset;
+                loop_end = (loop_end * 2) - start_offset;
+            }
+
+            vgmstream->coding_type = coding_PCM16BE;
+            vgmstream->num_samples = pcm_bytes_to_samples(stream_size, channel_count, 16);
+            if (loop_flag) {
+                vgmstream->loop_start_sample = loop_start;
+                vgmstream->loop_end_sample = loop_end;
+            }
+            break;
+
+        case 4: /* supposedly PCM8 */
+        default:
+            goto fail;
     }
 
+    vgmstream->stream_size = stream_size;
 
-	close_streamfile(streamFileSPT); streamFileSPT=NULL;
+    if (!vgmstream_open_stream(vgmstream,streamFile,start_offset))
+        goto fail;
+    close_streamfile(sf_h);
     return vgmstream;
 
-    /* clean up anything we may have opened */
 fail:
-    if (streamFileSPT) close_streamfile(streamFileSPT);
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_streamfile(sf_h);
+    close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/sqex_scd.c
+++ b/src/meta/sqex_scd.c
@@ -270,13 +270,15 @@ VGMSTREAM * init_vgmstream_sqex_scd(STREAMFILE *streamFile) {
         case 0x0C:      /* MS ADPCM [Final Fantasy XIV (PC) sfx] */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = read_16bit(extradata_offset+0x0c,streamFile);
-            /* in extradata_offset is a WAVEFORMATEX (including coefs and all) */
+            vgmstream->frame_size = read_16bit(extradata_offset + 0x0c, streamFile);
+            /* WAVEFORMATEX in extradata_offset */
+            if (!msadpcm_check_coefs(streamFile, extradata_offset + 0x14))
+                goto fail;
 
-            vgmstream->num_samples = msadpcm_bytes_to_samples(stream_size, vgmstream->interleave_block_size, vgmstream->channels);
+            vgmstream->num_samples = msadpcm_bytes_to_samples(stream_size, vgmstream->frame_size, vgmstream->channels);
             if (loop_flag) {
-                vgmstream->loop_start_sample = msadpcm_bytes_to_samples(loop_start, vgmstream->interleave_block_size, vgmstream->channels);
-                vgmstream->loop_end_sample = msadpcm_bytes_to_samples(loop_end, vgmstream->interleave_block_size, vgmstream->channels);
+                vgmstream->loop_start_sample = msadpcm_bytes_to_samples(loop_start, vgmstream->frame_size, vgmstream->channels);
+                vgmstream->loop_end_sample = msadpcm_bytes_to_samples(loop_end, vgmstream->frame_size, vgmstream->channels);
             }
             break;
 

--- a/src/meta/sqex_scd.c
+++ b/src/meta/sqex_scd.c
@@ -416,23 +416,24 @@ fail:
 
 #ifdef VGM_USE_VORBIS
 static void scd_ogg_v2_decryption_callback(void *ptr, size_t size, size_t nmemb, void *datasource) {
-    size_t bytes_read = size*nmemb;
-    ogg_vorbis_streamfile * ov_streamfile = (ogg_vorbis_streamfile*)datasource;
+    uint8_t *ptr8 = ptr;
+    size_t bytes_read = size * nmemb;
+    ogg_vorbis_io *io = datasource;
 
     /* no encryption, sometimes happens */
-    if (ov_streamfile->scd_xor == 0x00)
+    if (io->scd_xor == 0x00)
         return;
 
     /* header is XOR'd with a constant byte */
-    if (ov_streamfile->offset < ov_streamfile->scd_xor_length) {
+    if (io->offset < io->scd_xor_length) {
         int i, num_crypt;
 
-        num_crypt = ov_streamfile->scd_xor_length - ov_streamfile->offset;
+        num_crypt = io->scd_xor_length - io->offset;
         if (num_crypt > bytes_read)
             num_crypt = bytes_read;
 
         for (i = 0; i < num_crypt; i++) {
-            ((uint8_t*)ptr)[i] ^= (uint8_t)ov_streamfile->scd_xor;
+            ptr8[i] ^= (uint8_t)io->scd_xor;
         }
     }
 }
@@ -457,25 +458,25 @@ static void scd_ogg_v3_decryption_callback(void *ptr, size_t size, size_t nmemb,
         0xE2, 0xA2, 0x67, 0x32, 0x32, 0x12, 0x32, 0xB2, 0x32, 0x32, 0x32, 0x32, 0x75, 0xA3, 0x26, 0x7B, // E0-EF
         0x83, 0x26, 0xF9, 0x83, 0x2E, 0xFF, 0xE3, 0x16, 0x7D, 0xC0, 0x1E, 0x63, 0x21, 0x07, 0xE3, 0x01, // F0-FF
     };
-
-    size_t bytes_read = size*nmemb;
-    ogg_vorbis_streamfile *ov_streamfile = (ogg_vorbis_streamfile*)datasource;
+    uint8_t *ptr8 = ptr;
+    size_t bytes_read = size * nmemb;
+    ogg_vorbis_io *io = datasource;
 
     /* file is XOR'd with a table (algorithm and table by Ioncannon) */
-    { //if (ov_streamfile->offset < ov_streamfile->scd_xor_length)
+    { //if (io->offset < io->scd_xor_length)
         int i, num_crypt;
         uint8_t byte1, byte2, xor_byte;
 
         num_crypt = bytes_read;
-        byte1 = ov_streamfile->scd_xor & 0x7F;
-        byte2 = ov_streamfile->scd_xor & 0x3F;
+        byte1 = io->scd_xor & 0x7F;
+        byte2 = io->scd_xor & 0x3F;
 
         for (i = 0; i < num_crypt; i++) {
-            xor_byte = scd_ogg_v3_lookuptable[(byte2 + ov_streamfile->offset + i) & 0xFF];
+            xor_byte = scd_ogg_v3_lookuptable[(byte2 + io->offset + i) & 0xFF];
             xor_byte &= 0xFF;
-            xor_byte ^= ((uint8_t*)ptr)[i];
+            xor_byte ^= ptr8[i];
             xor_byte ^= byte1;
-            ((uint8_t*)ptr)[i] = (uint8_t)xor_byte;
+            ptr8[i] = xor_byte;
         }
     }
 }

--- a/src/meta/sqex_sead.c
+++ b/src/meta/sqex_sead.c
@@ -125,11 +125,11 @@ VGMSTREAM * init_vgmstream_sqex_sead(STREAMFILE * streamFile) {
             /* 0x00 (2): null?, 0x02(2): entry size? */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = read_16bit(sead.extradata_offset+0x04,streamFile);
+            vgmstream->frame_size = read_16bit(sead.extradata_offset+0x04,streamFile);
 
             /* much like AKBs, there are slightly different loop values here, probably more accurate
              * (if no loop, loop_end doubles as num_samples) */
-            vgmstream->num_samples = msadpcm_bytes_to_samples(sead.stream_size, vgmstream->interleave_block_size, vgmstream->channels);
+            vgmstream->num_samples = msadpcm_bytes_to_samples(sead.stream_size, vgmstream->frame_size, vgmstream->channels);
             vgmstream->loop_start_sample = read_32bit(sead.extradata_offset+0x08, streamFile); //loop_start
             vgmstream->loop_end_sample   = read_32bit(sead.extradata_offset+0x0c, streamFile); //loop_end
             break;

--- a/src/meta/txth.c
+++ b/src/meta/txth.c
@@ -772,12 +772,12 @@ static int parse_txth(txth_header * txth) {
 
     /* read lines */
     while (txt_offset < file_size) {
-        char line[TXT_LINE_MAX] = {0};
+        char line[TXT_LINE_MAX];
         char key[TXT_LINE_MAX] = {0}, val[TXT_LINE_MAX] = {0}; /* at least as big as a line to avoid overflows (I hope) */
-        int ok, bytes_read, line_done;
+        int ok, bytes_read, line_ok;
 
-        bytes_read = get_streamfile_text_line(TXT_LINE_MAX,line, txt_offset,txth->streamText, &line_done);
-        if (!line_done) goto fail;
+        bytes_read = read_line(line, sizeof(line), txt_offset, txth->streamText, &line_ok);
+        if (!line_ok) goto fail;
         //;VGM_LOG("TXTH: line=%s\n",line);
 
         txt_offset += bytes_read;
@@ -1441,12 +1441,12 @@ static int parse_name_table(txth_header * txth, char * name_list) {
 
     /* read lines and find target filename, format is (filename): value1, ... valueN */
     while (txt_offset < file_size) {
-        char line[TXT_LINE_MAX] = {0};
+        char line[TXT_LINE_MAX];
         char key[TXT_LINE_MAX] = {0}, val[TXT_LINE_MAX] = {0};
-        int ok, bytes_read, line_done;
+        int ok, bytes_read, line_ok;
 
-        bytes_read = get_streamfile_text_line(TXT_LINE_MAX,line, txt_offset,nameFile, &line_done);
-        if (!line_done) goto fail;
+        bytes_read = read_line(line, sizeof(line), txt_offset, nameFile, &line_ok);
+        if (!line_ok) goto fail;
         //;VGM_LOG("TXTH: line=%s\n",line);
 
         txt_offset += bytes_read;

--- a/src/meta/txth.c
+++ b/src/meta/txth.c
@@ -337,13 +337,15 @@ VGMSTREAM * init_vgmstream_txth(STREAMFILE *streamFile) {
             vgmstream->interleave_block_size = txth.interleave;
             vgmstream->layout_type = layout_none;
             break;
+
         case coding_MSADPCM:
             if (vgmstream->channels > 2) goto fail;
-            if (!txth.interleave) goto fail; /* creates garbage */
+            if (!txth.interleave) goto fail;
 
-            vgmstream->interleave_block_size = txth.interleave;
+            vgmstream->frame_size = txth.interleave;
             vgmstream->layout_type = layout_none;
             break;
+
         case coding_XBOX_IMA:
             if (txth.codec_mode == 1) { /* mono interleave */
                 coding = coding_XBOX_IMA_int;

--- a/src/meta/txtp.c
+++ b/src/meta/txtp.c
@@ -1434,13 +1434,13 @@ static txtp_header* parse_txtp(STREAMFILE* streamFile) {
 
     /* read and parse lines */
     while (txt_offset < file_size) {
-        char line[TXTP_LINE_MAX] = {0};
+        char line[TXTP_LINE_MAX];
         char key[TXTP_LINE_MAX] = {0}, val[TXTP_LINE_MAX] = {0}; /* at least as big as a line to avoid overflows (I hope) */
         char filename[TXTP_LINE_MAX] = {0};
-        int ok, bytes_read, line_done;
+        int ok, bytes_read, line_ok;
 
-        bytes_read = get_streamfile_text_line(TXTP_LINE_MAX,line, txt_offset,streamFile, &line_done);
-        if (!line_done) goto fail;
+        bytes_read = read_line(line, sizeof(line), txt_offset, streamFile, &line_ok);
+        if (!line_ok) goto fail;
 
         txt_offset += bytes_read;
 

--- a/src/meta/ubi_bao.c
+++ b/src/meta/ubi_bao.c
@@ -379,22 +379,17 @@ static VGMSTREAM * init_vgmstream_ubi_bao_base(ubi_bao_header * bao, STREAMFILE 
             vgmstream->layout_type = layout_none;
             break;
         }
-
+#endif
+#ifdef VGM_USE_VORBIS
         case FMT_OGG: {
-            ffmpeg_codec_data *ffmpeg_data;
-
-            ffmpeg_data = init_ffmpeg_offset(streamData, start_offset, bao->stream_size);
-            if (!ffmpeg_data) goto fail;
-            vgmstream->codec_data = ffmpeg_data;
-            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->codec_data = init_ogg_vorbis(streamData, start_offset, bao->stream_size, NULL);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_OGG_VORBIS;
             vgmstream->layout_type = layout_none;
 
-            vgmstream->num_samples = bao->num_samples; /* ffmpeg_data->totalSamples */
-            VGM_ASSERT(bao->num_samples != ffmpeg_data->totalSamples,
-                    "UBI BAO: header samples %i vs ffmpeg %i differ\n", bao->num_samples, (uint32_t)ffmpeg_data->totalSamples);
+            vgmstream->num_samples = bao->num_samples; /* same as Ogg samples */
             break;
         }
-
 #endif
         default:
             goto fail;

--- a/src/meta/ubi_hx.c
+++ b/src/meta/ubi_hx.c
@@ -107,10 +107,10 @@ static int parse_name_bnh(ubi_hx_header * hx, STREAMFILE *sf, uint32_t cuuid1, u
 
     /* each .bnh line has a cuuid, a bunch of repeated fields and name (sometimes name is filename or "bad name") */
     while (txt_offset < get_streamfile_size(sf)) {
-        int line_read, bytes_read;
+        int line_ok, bytes_read;
 
-        bytes_read = get_streamfile_text_line(TXT_LINE_MAX,line, txt_offset,sf_t, &line_read);
-        if (!line_read) break;
+        bytes_read = read_line(line, sizeof(line), txt_offset, sf_t, &line_ok);
+        if (!line_ok) break;
         txt_offset += bytes_read;
 
         if (strncmp(line,cuuid,31) != 0)

--- a/src/meta/ubi_jade.c
+++ b/src/meta/ubi_jade.c
@@ -209,9 +209,9 @@ VGMSTREAM * init_vgmstream_ubi_jade(STREAMFILE *streamFile) {
 
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = 0x24*channel_count;
+            vgmstream->frame_size = block_size;
 
-            vgmstream->num_samples = msadpcm_bytes_to_samples(data_size, vgmstream->interleave_block_size, channel_count);
+            vgmstream->num_samples = msadpcm_bytes_to_samples(data_size, vgmstream->frame_size, channel_count);
             if (!is_jade_v2) {
                 vgmstream->loop_start_sample = 0;
                 vgmstream->loop_end_sample = vgmstream->num_samples;
@@ -221,7 +221,7 @@ VGMSTREAM * init_vgmstream_ubi_jade(STREAMFILE *streamFile) {
 
         case 0x0001: { /* PS3 */
             VGMSTREAM *temp_vgmstream = NULL;
-            STREAMFILE *temp_streamFile = NULL;
+            STREAMFILE *temp_sf = NULL;
 
             if (fmt_size != 0x10) goto fail;
             if (block_size != 0x02*channel_count) goto fail;
@@ -230,11 +230,11 @@ VGMSTREAM * init_vgmstream_ubi_jade(STREAMFILE *streamFile) {
             if (read_32bitBE(start_offset, streamFile) != 0x4D534643) /* "MSF\43" */
                 goto fail;
 
-            temp_streamFile = setup_subfile_streamfile(streamFile, start_offset, data_size, "msf");
-            if (!temp_streamFile) goto fail;
+            temp_sf = setup_subfile_streamfile(streamFile, start_offset, data_size, "msf");
+            if (!temp_sf) goto fail;
 
-            temp_vgmstream = init_vgmstream_msf(temp_streamFile);
-            close_streamfile(temp_streamFile);
+            temp_vgmstream = init_vgmstream_msf(temp_sf);
+            close_streamfile(temp_sf);
             if (!temp_vgmstream) goto fail;
 
             temp_vgmstream->meta_type = vgmstream->meta_type;

--- a/src/meta/ubi_raki.c
+++ b/src/meta/ubi_raki.c
@@ -94,9 +94,12 @@ VGMSTREAM * init_vgmstream_ubi_raki(STREAMFILE *streamFile) {
             /* chunks: "data" */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = block_align;
+            vgmstream->frame_size = block_align;
 
-            vgmstream->num_samples = msadpcm_bytes_to_samples(data_size, vgmstream->interleave_block_size, channel_count);
+            vgmstream->num_samples = msadpcm_bytes_to_samples(data_size, vgmstream->frame_size, channel_count);
+
+            if (!msadpcm_check_coefs(streamFile, fmt_offset + 0x14))
+                goto fail;
             break;
 
         case 0x5769692061647063:    /* "Wii adpc" */

--- a/src/meta/ubi_sb.c
+++ b/src/meta/ubi_sb.c
@@ -661,14 +661,12 @@ static VGMSTREAM * init_vgmstream_ubi_sb_base(ubi_sb_header *sb, STREAMFILE *str
             xma_fix_raw_samples_ch(vgmstream, streamData, start_offset, sb->stream_size, sb->channels, 0, 0);
             break;
         }
-
+#endif
+#ifdef VGM_USE_VORBIS
         case FMT_OGG: {
-            ffmpeg_codec_data *ffmpeg_data;
-
-            ffmpeg_data = init_ffmpeg_offset(streamData, start_offset, sb->stream_size);
-            if ( !ffmpeg_data ) goto fail;
-            vgmstream->codec_data = ffmpeg_data;
-            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->codec_data = init_ogg_vorbis(streamData, start_offset, sb->stream_size, NULL);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_OGG_VORBIS;
             vgmstream->layout_type = layout_none;
             break;
         }

--- a/src/meta/xa.c
+++ b/src/meta/xa.c
@@ -2,20 +2,25 @@
 #include "../layout/layout.h"
 #include "../coding/coding.h"
 
-/* CD-XA - from Sony PS1 and Philips CD-i CD audio */
+/* CD-XA - from Sony PS1 and Philips CD-i CD audio, also Saturn streams */
 VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     off_t start_offset;
     int loop_flag = 0, channel_count, sample_rate;
-    int is_blocked;
-    size_t file_size = get_streamfile_size(streamFile);
+    int is_riff = 0, is_blocked = 0;
+    size_t file_size, stream_size;
+    int total_subsongs, /*target_subsong = streamFile->stream_index,*/ target_config;
 
 
     /* checks
-     * .xa: common, .str: sometimes (mainly videos)
+     * .xa: common
+     * .str: often (but not always) videos
      * .adp: Phantasy Star Collection (SAT) raw XA */
     if ( !check_extensions(streamFile,"xa,str,adp") )
         goto fail;
+
+
+    file_size = get_streamfile_size(streamFile);
 
     /* Proper XA comes in raw (BIN 2352 mode2/form2) CD sectors, that contain XA subheaders.
      * This also has minimal support for headerless (ISO 2048 mode1/data) mode. */
@@ -25,6 +30,7 @@ VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
         read_32bitBE(0x08,streamFile) == 0x43445841 &&  /* "CDXA" */
         read_32bitBE(0x0C,streamFile) == 0x666D7420) {  /* "fmt " */
         is_blocked = 1;
+        is_riff = 1;
         start_offset = 0x2c; /* after "data" (chunk size tends to be a bit off) */
     }
     else {
@@ -36,22 +42,34 @@ VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
             start_offset = 0x00;
         }
         else { /* headerless and possibly incorrectly ripped */
-            is_blocked = 0;
             start_offset = 0x00;
         }
     }
 
     /* test some blocks (except when RIFF) since other .XA/STR may start blank */
-    if (start_offset == 0) {
-        int i, j, block;
+    if (!is_riff) {
+        int i, j, block = 0, miss = 0;
         off_t test_offset = start_offset;
-        size_t sector_size = (is_blocked ? 0x900 : 0x800);
-        size_t block_size = 0x80;
+        const size_t sector_size = (is_blocked ? 0x900 : 0x800);
+        const size_t block_size = 0x80;
+        const int block_max = 3;
+        const int miss_max = 25;
 
-        for (block = 0; block < 3; block++) {
+        while (block < block_max) {
+            uint8_t xa_submode = read_u8(test_offset + 0x12, streamFile);
+            int is_audio = !(xa_submode & 0x08) && (xa_submode & 0x04) && !(xa_submode & 0x02);
+
+            if (is_blocked && !is_audio) {
+                miss++;
+                if (block == 0 && miss > miss_max) /* no a single audio block found */
+                    goto fail;
+                test_offset += sector_size + (is_blocked ? 0x18 + 0x18 : 0);
+                continue;
+            }
+
             test_offset += (is_blocked ? 0x18 : 0x00); /* header */
 
-            for (i = 0; i < (sector_size/block_size); i++) {
+            for (i = 0; i < (sector_size / block_size); i++) {
                 /* XA headers checks: filter indexes should be 0..3, and shifts 0..C */
                 for (j = 0; j < 16; j++) {
                     uint8_t header = (uint8_t)read_8bit(test_offset + j, streamFile);
@@ -75,13 +93,72 @@ VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
             }
 
             test_offset += (is_blocked ? 0x18 : 0x00); /* footer */
+            block++;
+        }
+    }
+
+    /* find subsongs as XA can interleave sectors using 'file' and 'channel' makers (see blocked_xa.c) */
+    if (is_blocked) {
+        off_t offset;
+        STREAMFILE *sf_test = NULL;
+
+        /* mini buffer to speed up by reading headers only (not sure if O.S. has buffer though */
+        sf_test = reopen_streamfile(streamFile, 0x10);
+        if (!sf_test) goto fail;
+
+        //TODO add subsongs (optimized for giant xa)
+        // - only do if first sector and next sector have different channels?
+        //   N sectors of the same channel then N sectors of another should't happen, but
+        //   we need to read all sectors to count samples anyway.
+        // - read all sectors
+        // - skip non-audio sectors
+        // - find first actual stream start
+        // - detect file+channel change + register new subsong (or detect file end flags too)
+        // - save total sectors subsong_sectors[subsong] = N for quick sample calcs + stream size
+        //   (block_update is much slower since it buffers all data)
+        total_subsongs = 0;
+
+        target_config = -1;
+
+        offset = start_offset;
+        while (offset < file_size) {
+            uint16_t xa_subheader = read_u16be(offset + 0x10, sf_test);
+            uint8_t  xa_submode   = read_u8   (offset + 0x12, sf_test);
+            int is_audio = !(xa_submode & 0x08) && (xa_submode & 0x04) && !(xa_submode & 0x02);
+
+            if (!is_audio)  {
+                offset += 0x900 + 0x18 + 0x18;
+                continue;
+            }
+
+
+            //if target_subsong ..
+            //total_subsongs++
+            //...
+            target_config = xa_subheader;
+            start_offset = offset; //stream_offset
+            break;
+        }
+
+        close_streamfile(sf_test);
+
+        stream_size = file_size;
+        //stream_size = ...;
+
+        //if (target_subsong == 0) target_subsong = 1;
+        //if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
+
+        /* file has no audio */
+        if (target_config < 0) {
+            VGM_LOG("XA: no audio found");
+            goto fail;
         }
     }
 
 
     /* data is ok: parse header */
     if (is_blocked) {
-        /* parse 0x18 sector header (also see xa_blocked.c)  */
+        /* parse 0x18 sector header (also see blocked_xa.c)  */
         uint8_t xa_header = (uint8_t)read_8bit(start_offset + 0x13,streamFile);
 
         switch((xa_header >> 0) & 3) { /* 0..1: mono/stereo */
@@ -94,9 +171,9 @@ VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
             case 1: sample_rate = 18900; break;
             default: goto fail;
         }
-        switch((xa_header >> 4) & 3) { /* 4..5: bits per sample (0=4, 1=8) */
+        switch((xa_header >> 4) & 3) { /* 4..5: bits per sample (0=4-bit ADPCM, 1=8-bit ADPCM) */
             case 0: break;
-            default: /* PS1 games only do 4b */
+            default: /* PS1 games only do 4-bit */
                 VGM_LOG("XA: unknown bits per sample found\n");
                 goto fail;
         }
@@ -150,10 +227,15 @@ VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
     vgmstream->coding_type = coding_XA;
     vgmstream->layout_type = is_blocked ? layout_blocked_xa : layout_none;
 
-    /* open the file for reading */
+    if (is_blocked) {
+        vgmstream->codec_config = target_config;
+        vgmstream->num_streams = total_subsongs;
+        vgmstream->stream_size = stream_size;
+    }
+
+
     if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
         goto fail;
-
 
     if (is_blocked) {
         /* calc num_samples as blocks may be empty or smaller than usual depending on flags */
@@ -162,7 +244,7 @@ VGMSTREAM * init_vgmstream_xa(STREAMFILE *streamFile) {
             block_update(vgmstream->next_block_offset,vgmstream);
             vgmstream->num_samples += vgmstream->current_block_samples;
         }
-        while (vgmstream->next_block_offset < get_streamfile_size(streamFile));
+        while (vgmstream->next_block_offset < file_size);
         block_update(start_offset,vgmstream);
     }
     else {

--- a/src/meta/xnb.c
+++ b/src/meta/xnb.c
@@ -79,7 +79,12 @@ VGMSTREAM * init_vgmstream_xnb(STREAMFILE *streamFile) {
             block_align   = read_16bit(current_offset+0x0c, streamFile);
             bps           = read_16bit(current_offset+0x0e, streamFile);
 
-            if (codec == 0x166) {
+            if (codec == 0x0002) {
+                if (!msadpcm_check_coefs(streamFile, current_offset + 0x14))
+                    goto fail;
+            }
+
+            if (codec == 0x0166) {
                 xma2_parse_fmt_chunk_extra(streamFile, current_offset, &loop_flag, &num_samples, &loop_start, &loop_end, big_endian);
                 xma_chunk_offset = current_offset;
             }
@@ -122,7 +127,7 @@ VGMSTREAM * init_vgmstream_xnb(STREAMFILE *streamFile) {
             if (!block_align) goto fail;
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = block_align;
+            vgmstream->frame_size = block_align;
             vgmstream->num_samples = msadpcm_bytes_to_samples(data_size, block_align, channel_count);
             break;
 

--- a/src/meta/xwb.c
+++ b/src/meta/xwb.c
@@ -449,7 +449,7 @@ VGMSTREAM * init_vgmstream_xwb(STREAMFILE *streamFile) {
         case MS_ADPCM: /* Persona 4 Ultimax (AC) */
             vgmstream->coding_type = coding_MSADPCM;
             vgmstream->layout_type = layout_none;
-            vgmstream->interleave_block_size = (xwb.block_align + 22) * xwb.channels; /*22=CONVERSION_OFFSET (?)*/
+            vgmstream->frame_size = (xwb.block_align + 22) * xwb.channels; /*22=CONVERSION_OFFSET (?)*/
             break;
 
 #ifdef VGM_USE_FFMPEG

--- a/src/meta/xwb.c
+++ b/src/meta/xwb.c
@@ -540,11 +540,12 @@ VGMSTREAM * init_vgmstream_xwb(STREAMFILE *streamFile) {
             vgmstream->layout_type = layout_none;
             break;
         }
-
+#endif
+#ifdef VGM_USE_VORBIS
         case OGG: { /* Oddworld: Strangers Wrath (iOS/Android) extension */
-            vgmstream->codec_data = init_ffmpeg_offset(streamFile, xwb.stream_offset, xwb.stream_size);
-            if ( !vgmstream->codec_data ) goto fail;
-            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->codec_data = init_ogg_vorbis(streamFile, xwb.stream_offset, xwb.stream_size, NULL);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_OGG_VORBIS;
             vgmstream->layout_type = layout_none;
             break;
         }

--- a/src/meta/xwc.c
+++ b/src/meta/xwc.c
@@ -97,14 +97,15 @@ VGMSTREAM * init_vgmstream_xwc(STREAMFILE *streamFile) {
             xma_fix_raw_samples(vgmstream, streamFile, start_offset,data_size, 0, 0,0); /* samples are ok, fix delay */
             break;
         }
-
+#endif
+#ifdef VGM_USE_VORBIS
         case 0x564F5242: { /* "VORB" (PC) */
             start_offset = 0x30;
             data_size = data_size - start_offset;
 
-            vgmstream->codec_data = init_ffmpeg_offset(streamFile, start_offset,data_size);
+            vgmstream->codec_data = init_ogg_vorbis(streamFile, start_offset, data_size, NULL);
             if ( !vgmstream->codec_data ) goto fail;
-            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->coding_type = coding_OGG_VORBIS;
             vgmstream->layout_type = layout_none;
 
             vgmstream->sample_rate = read_32bitLE(start_offset + 0x28, streamFile);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -138,8 +138,8 @@ void vgmstream_tags_close(VGMSTREAM_TAGS *tags) {
 int vgmstream_tags_next_tag(VGMSTREAM_TAGS* tags, STREAMFILE* tagfile) {
     off_t file_size = get_streamfile_size(tagfile);
     char currentname[VGMSTREAM_TAGS_LINE_MAX] = {0};
-    char line[VGMSTREAM_TAGS_LINE_MAX] = {0};
-    int ok, bytes_read, line_done, n1,n2;
+    char line[VGMSTREAM_TAGS_LINE_MAX];
+    int ok, bytes_read, line_ok, n1,n2;
 
     if (!tags)
         return 0;
@@ -193,8 +193,8 @@ int vgmstream_tags_next_tag(VGMSTREAM_TAGS* tags, STREAMFILE* tagfile) {
             goto fail;
         }
 
-        bytes_read = get_streamfile_text_line(VGMSTREAM_TAGS_LINE_MAX,line, tags->offset,tagfile, &line_done);
-        if (!line_done || bytes_read == 0) goto fail;
+        bytes_read = read_line(line, sizeof(line), tags->offset, tagfile, &line_ok);
+        if (!line_ok || bytes_read == 0) goto fail;
 
         tags->offset += bytes_read;
 

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -59,12 +59,12 @@
  * to do file operations, as plugins may need to provide their own callbacks.
  * Reads from arbitrary offsets, meaning internally may need fseek equivalents during reads. */
 typedef struct _STREAMFILE {
-    size_t (*read)(struct _STREAMFILE *,uint8_t * dest, off_t offset, size_t length);
+    size_t (*read)(struct _STREAMFILE *, uint8_t * dst, off_t offset, size_t length);
     size_t (*get_size)(struct _STREAMFILE *);
     off_t (*get_offset)(struct _STREAMFILE *);   //todo: DO NOT USE, NOT RESET PROPERLY (remove?)
     /* for dual-file support */
-    void (*get_name)(struct _STREAMFILE *,char *name,size_t length);
-    struct _STREAMFILE * (*open)(struct _STREAMFILE *,const char * const filename,size_t buffersize);
+    void (*get_name)(struct _STREAMFILE * ,char *name, size_t length);
+    struct _STREAMFILE * (*open)(struct _STREAMFILE *, const char * const filename, size_t buffersize);
     void (*close)(struct _STREAMFILE *);
 
 
@@ -74,59 +74,68 @@ typedef struct _STREAMFILE {
 
 } STREAMFILE;
 
+/* All open_ fuctions should be safe to call with wrong/null parameters.
+ * _f versions are the same but free the passed streamfile on failure and return NULL,
+ * to ease chaining by avoiding realloc-style temp ptr verbosity */
+
 /* Opens a standard STREAMFILE, opening from path.
  * Uses stdio (FILE) for operations, thus plugins may not want to use it. */
-STREAMFILE *open_stdio_streamfile(const char * filename);
+STREAMFILE* open_stdio_streamfile(const char *filename);
 
 /* Opens a standard STREAMFILE from a pre-opened FILE. */
-STREAMFILE *open_stdio_streamfile_by_file(FILE * file, const char * filename);
+STREAMFILE* open_stdio_streamfile_by_file(FILE *file, const char *filename);
 
 /* Opens a STREAMFILE that does buffered IO.
  * Can be used when the underlying IO may be slow (like when using custom IO).
  * Buffer size is optional. */
-STREAMFILE *open_buffer_streamfile(STREAMFILE *streamfile, size_t buffer_size);
+STREAMFILE* open_buffer_streamfile(STREAMFILE *streamfile, size_t buffer_size);
+STREAMFILE* open_buffer_streamfile_f(STREAMFILE *streamfile, size_t buffer_size);
 
 /* Opens a STREAMFILE that doesn't close the underlying streamfile.
  * Calls to open won't wrap the new SF (assumes it needs to be closed).
  * Can be used in metas to test custom IO without closing the external SF. */
-STREAMFILE *open_wrap_streamfile(STREAMFILE *streamfile);
+STREAMFILE* open_wrap_streamfile(STREAMFILE *streamfile);
+STREAMFILE* open_wrap_streamfile_f(STREAMFILE *streamfile);
 
 /* Opens a STREAMFILE that clamps reads to a section of a larger streamfile.
  * Can be used with subfiles inside a bigger file (to fool metas, or to simplify custom IO). */
-STREAMFILE *open_clamp_streamfile(STREAMFILE *streamfile, off_t start, size_t size);
+STREAMFILE* open_clamp_streamfile(STREAMFILE *streamfile, off_t start, size_t size);
+STREAMFILE* open_clamp_streamfile_f(STREAMFILE *streamfile, off_t start, size_t size);
 
 /* Opens a STREAMFILE that uses custom IO for streamfile reads.
  * Can be used to modify data on the fly (ex. decryption), or even transform it from a format to another. */
-STREAMFILE *open_io_streamfile(STREAMFILE *streamfile, void* data, size_t data_size, void* read_callback, void* size_callback);
+STREAMFILE* open_io_streamfile(STREAMFILE *streamfile, void *data, size_t data_size, void *read_callback, void *size_callback);
+STREAMFILE* open_io_streamfile_f(STREAMFILE *streamfile, void *data, size_t data_size, void *read_callback, void *size_callback);
 
 /* Opens a STREAMFILE that reports a fake name, but still re-opens itself properly.
  * Can be used to trick a meta's extension check (to call from another, with a modified SF).
  * When fakename isn't supplied it's read from the streamfile, and the extension swapped with fakeext.
  * If the fakename is an existing file, open won't work on it as it'll reopen the fake-named streamfile. */
-STREAMFILE *open_fakename_streamfile(STREAMFILE *streamfile, const char * fakename, const char * fakeext);
+STREAMFILE* open_fakename_streamfile(STREAMFILE *streamfile, const char * fakename, const char * fakeext);
+STREAMFILE* open_fakename_streamfile_f(STREAMFILE *streamfile, const char * fakename, const char * fakeext);
 
-//todo probably could simply use custom IO
 /* Opens streamfile formed from multiple streamfiles, their data joined during reads.
  * Can be used when data is segmented in multiple separate files.
  * The first streamfile is used to get names, stream index and so on. */
-STREAMFILE *open_multifile_streamfile(STREAMFILE **streamfiles, size_t streamfiles_size);
+STREAMFILE* open_multifile_streamfile(STREAMFILE **streamfiles, size_t streamfiles_size);
+STREAMFILE* open_multifile_streamfile_f(STREAMFILE **streamfiles, size_t streamfiles_size);
 
 /* Opens a STREAMFILE from a (path)+filename.
  * Just a wrapper, to avoid having to access the STREAMFILE's callbacks directly. */
-STREAMFILE * open_streamfile(STREAMFILE *streamFile, const char * pathname);
+STREAMFILE* open_streamfile(STREAMFILE *streamfile, const char * pathname);
 
 /* Opens a STREAMFILE from a base pathname + new extension
  * Can be used to get companion headers. */
-STREAMFILE * open_streamfile_by_ext(STREAMFILE *streamFile, const char * ext);
+STREAMFILE* open_streamfile_by_ext(STREAMFILE *streamfile, const char * ext);
 
 /* Opens a STREAMFILE from a base path + new filename.
  * Can be used to get companion files. Relative paths like
  * './filename', '../filename', 'dir/filename' also work. */
-STREAMFILE * open_streamfile_by_filename(STREAMFILE *streamFile, const char * filename);
+STREAMFILE* open_streamfile_by_filename(STREAMFILE *streamfile, const char * filename);
 
 /* Reopen a STREAMFILE with a different buffer size, for fine-tuned bigfile parsing.
  * Uses default buffer size when buffer_size is 0 */
-STREAMFILE * reopen_streamfile(STREAMFILE *streamFile, size_t buffer_size);
+STREAMFILE * reopen_streamfile(STREAMFILE *streamfile, size_t buffer_size);
 
 
 /* close a file, destroy the STREAMFILE object */
@@ -136,8 +145,8 @@ static inline void close_streamfile(STREAMFILE * streamfile) {
 }
 
 /* read from a file, returns number of bytes read */
-static inline size_t read_streamfile(uint8_t * dest, off_t offset, size_t length, STREAMFILE * streamfile) {
-    return streamfile->read(streamfile,dest,offset,length);
+static inline size_t read_streamfile(uint8_t *dst, off_t offset, size_t length, STREAMFILE *streamfile) {
+    return streamfile->read(streamfile, dst, offset,length);
 }
 
 /* return file size */
@@ -256,7 +265,7 @@ static inline size_t align_size_to_block(size_t value, size_t block_align) {
 
 /* various STREAMFILE helpers functions */
 
-size_t get_streamfile_text_line(int dst_length, char * dst, off_t offset, STREAMFILE * streamfile, int *line_done_ptr);
+size_t get_streamfile_text_line(int dst_length, char * dst, off_t offset, STREAMFILE *streamfile, int *line_done_ptr);
 
 size_t read_string(char * buf, size_t bufsize, off_t offset, STREAMFILE *streamFile);
 

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -265,16 +265,27 @@ static inline size_t align_size_to_block(size_t value, size_t block_align) {
 
 /* various STREAMFILE helpers functions */
 
-size_t get_streamfile_text_line(int dst_length, char * dst, off_t offset, STREAMFILE *streamfile, int *line_done_ptr);
+/* Read into dst a line delimited by CRLF (Windows) / LF (Unux) / CR (Mac) / EOF, null-terminated
+ * and without line feeds. Returns bytes read (including CR/LF), *not* the same as string length.
+ * p_line_ok is set to 1 if the complete line was read; pass NULL to ignore. */
+size_t read_line(char *buf, int buf_size, off_t offset, STREAMFILE *sf, int *p_line_ok);
 
-size_t read_string(char * buf, size_t bufsize, off_t offset, STREAMFILE *streamFile);
+/* reads a c-string (ANSI only), up to bufsize or NULL, returning size. buf is optional (works as get_string_size). */
+size_t read_string(char *buf, size_t buf_size, off_t offset, STREAMFILE *sf);
 
-size_t read_key_file(uint8_t * buf, size_t bufsize, STREAMFILE *streamFile);
+/* Opens a file containing decryption keys and copies to buffer.
+ * Tries "(name.ext)key" (per song), "(.ext)key" (per folder) keynames.
+ * returns size of key if found and copied */
+size_t read_key_file(uint8_t *buf, size_t buf_size, STREAMFILE *sf);
 
-void fix_dir_separators(char * filename);
+/* hack to allow relative paths in various OSs */
+void fix_dir_separators(char *filename);
 
+/* Checks if the stream filename is one of the extensions (comma-separated, ex. "adx" or "adx,aix").
+ * Empty is ok to accept files without extension ("", "adx,,aix"). Returns 0 on failure */
 int check_extensions(STREAMFILE *streamFile, const char * cmp_exts);
 
+/* chunk-style file helpers */
 int find_chunk_be(STREAMFILE *streamFile, uint32_t chunk_id, off_t start_offset, int full_chunk_size, off_t *out_chunk_offset, size_t *out_chunk_size);
 int find_chunk_le(STREAMFILE *streamFile, uint32_t chunk_id, off_t start_offset, int full_chunk_size, off_t *out_chunk_offset, size_t *out_chunk_size);
 int find_chunk(STREAMFILE *streamFile, uint32_t chunk_id, off_t start_offset, int full_chunk_size, off_t *out_chunk_offset, size_t *out_chunk_size, int big_endian_size, int zero_size_end);
@@ -284,7 +295,7 @@ int find_chunk_riff_be(STREAMFILE *streamFile, uint32_t chunk_id, off_t start_of
 /* same with chunk ids in variable endianess (so instead of "fmt " has " tmf" */
 int find_chunk_riff_ve(STREAMFILE *streamFile, uint32_t chunk_id, off_t start_offset, size_t max_size, off_t *out_chunk_offset, size_t *out_chunk_size, int big_endian);
 
-
+/* filename helpers */
 void get_streamfile_name(STREAMFILE *streamFile, char * buffer, size_t size);
 void get_streamfile_filename(STREAMFILE *streamFile, char * buffer, size_t size);
 void get_streamfile_basename(STREAMFILE *streamFile, char * buffer, size_t size);

--- a/src/streamtypes.h
+++ b/src/streamtypes.h
@@ -7,12 +7,20 @@
 #define _STREAMTYPES_H
 
 #ifdef _MSC_VER
+/* Common versions:
+ * - 1500: VS2008
+ * - 1600: VS2010
+ * - 1700: VS2012
+ * - 1800: VS2013
+ * - 1900: VS2015
+ * - 1920: VS2019 */
 
 #if (_MSC_VER >= 1600)
+
 #include <stdint.h>
 #else
 #include <pstdint.h>
-#endif /* (_MSC_VER >= 1600) */
+#endif
 
 #ifndef inline /* (_MSC_VER < 1900)? */
 #define inline _inline
@@ -23,10 +31,11 @@
 
 #if (_MSC_VER < 1900)
 #define snprintf _snprintf
-#endif /* (_MSC_VER < 1900) */
+#endif
 
 #else
 #include <stdint.h>
+
 #endif /* _MSC_VER */
 
 typedef int16_t sample; //TODO: deprecated, remove

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,22 @@ static inline int64_t get_64bitLE(uint8_t * p) {
     return (uint64_t)(((uint64_t)p[0]) | ((uint64_t)p[1]<<8) | ((uint64_t)p[2]<<16) | ((uint64_t)p[3]<<24) | ((uint64_t)p[4]<<32) | ((uint64_t)p[5]<<40) | ((uint64_t)p[6]<<48) | ((uint64_t)p[7]<<56));
 }
 
+/* alias of the above */
+static inline  int8_t  get_s8   (uint8_t *p) { return ( int8_t)p[0]; }
+static inline uint8_t  get_u8   (uint8_t *p) { return (uint8_t)p[0]; }
+static inline  int16_t get_s16le(uint8_t *p) { return ( int16_t)get_16bitLE(p); }
+static inline uint16_t get_u16le(uint8_t *p) { return (uint16_t)get_16bitLE(p); }
+static inline  int16_t get_s16be(uint8_t *p) { return ( int16_t)get_16bitBE(p); }
+static inline uint16_t get_u16be(uint8_t *p) { return (uint16_t)get_16bitBE(p); }
+static inline  int32_t get_s32le(uint8_t *p) { return ( int32_t)get_32bitLE(p); }
+static inline uint32_t get_u32le(uint8_t *p) { return (uint32_t)get_32bitLE(p); }
+static inline  int32_t get_s32be(uint8_t *p) { return ( int32_t)get_32bitBE(p); }
+static inline uint32_t get_u32be(uint8_t *p) { return (uint32_t)get_32bitBE(p); }
+static inline  int64_t get_s64be(uint8_t *p) { return ( int64_t)get_64bitLE(p); }
+static inline uint64_t get_u64be(uint8_t *p) { return (uint64_t)get_64bitLE(p); }
+static inline  int64_t get_s64le(uint8_t *p) { return ( int64_t)get_64bitBE(p); }
+static inline uint64_t get_u64le(uint8_t *p) { return (uint64_t)get_64bitBE(p); }
+
 void put_8bit(uint8_t * buf, int8_t i);
 
 void put_16bitLE(uint8_t * buf, int16_t i);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -1215,10 +1215,10 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
             return 128;
 
         case coding_MSADPCM:
-            return (vgmstream->interleave_block_size - 0x07*vgmstream->channels)*2 / vgmstream->channels + 2;
+            return (vgmstream->frame_size - 0x07*vgmstream->channels)*2 / vgmstream->channels + 2;
         case coding_MSADPCM_int:
         case coding_MSADPCM_ck:
-            return (vgmstream->interleave_block_size - 0x07)*2 + 2;
+            return (vgmstream->frame_size - 0x07)*2 + 2;
         case coding_WS: /* only works if output sample size is 8 bit, which always is for WS ADPCM */
             return vgmstream->ws_output_size;
         case coding_AICA:
@@ -1407,7 +1407,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
         case coding_MSADPCM:
         case coding_MSADPCM_int:
         case coding_MSADPCM_ck:
-            return vgmstream->interleave_block_size;
+            return vgmstream->frame_size;
         case coding_WS:
             return vgmstream->current_block_size;
         case coding_AICA:
@@ -2393,7 +2393,8 @@ void describe_vgmstream(VGMSTREAM * vgmstream, char * desc, int length) {
     }
 
     /* codecs with configurable frame size */
-    if (vgmstream->interleave_block_size > 0) {
+    if (vgmstream->frame_size > 0 || vgmstream->interleave_block_size > 0) {
+        int32_t frame_size = vgmstream->frame_size > 0 ? vgmstream->frame_size : vgmstream->interleave_block_size;
         switch (vgmstream->coding_type) {
             case coding_MSADPCM:
             case coding_MSADPCM_int:
@@ -2403,7 +2404,7 @@ void describe_vgmstream(VGMSTREAM * vgmstream, char * desc, int length) {
             case coding_WWISE_IMA:
             case coding_REF_IMA:
             case coding_PSX_cfg:
-                snprintf(temp,TEMPSIZE, "frame size: %#x bytes\n", (int32_t)vgmstream->interleave_block_size);
+                snprintf(temp,TEMPSIZE, "frame size: %#x bytes\n", frame_size);
                 concatn(length,desc,temp);
                 break;
             default:
@@ -2792,7 +2793,7 @@ int vgmstream_open_stream(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t s
             vgmstream->coding_type == coding_PSX_pivotal) &&
             (vgmstream->interleave_block_size == 0 || vgmstream->interleave_block_size > 0x50)) {
         VGM_LOG("VGMSTREAM: PSX-cfg decoder with wrong frame size %x\n", vgmstream->interleave_block_size);
-        return 0;
+        goto fail;
     }
 
     if ((vgmstream->coding_type == coding_CRI_ADX ||
@@ -2802,7 +2803,14 @@ int vgmstream_open_stream(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t s
             vgmstream->coding_type == coding_CRI_ADX_fixed) &&
             (vgmstream->interleave_block_size == 0 || vgmstream->interleave_block_size > 0x12)) {
         VGM_LOG("VGMSTREAM: ADX decoder with wrong frame size %x\n", vgmstream->interleave_block_size);
-        return 0;
+        goto fail;
+    }
+
+    if ((vgmstream->coding_type == coding_MSADPCM ||
+            vgmstream->coding_type == coding_MSADPCM_ck ||
+            vgmstream->coding_type == coding_MSADPCM_int) &&
+            vgmstream->frame_size == 0) {
+        vgmstream->frame_size = vgmstream->interleave_block_size;
     }
 
     /* if interleave is big enough keep a buffer per channel */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -2628,8 +2628,7 @@ static STREAMFILE * get_vgmstream_average_bitrate_channel_streamfile(VGMSTREAM *
 
 #ifdef VGM_USE_VORBIS
     if (vgmstream->coding_type == coding_OGG_VORBIS) {
-        ogg_vorbis_codec_data *data = vgmstream->codec_data;
-        return data ? data->ov_streamfile.streamfile : NULL;
+        return ogg_vorbis_get_streamfile(vgmstream->codec_data);
     }
 #endif
     if (vgmstream->coding_type == coding_CRI_HCA) {

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -897,7 +897,8 @@ typedef struct {
 } VGMSTREAM;
 
 #ifdef VGM_USE_VORBIS
-/* Ogg with Vorbis */
+
+/* standard Ogg Vorbis */
 typedef struct {
     STREAMFILE *streamfile;
     ogg_int64_t start; /* file offset where the Ogg starts */
@@ -910,15 +911,9 @@ typedef struct {
     off_t scd_xor_length;
     uint32_t xor_value;
 
-} ogg_vorbis_streamfile;
+} ogg_vorbis_io;
 
-typedef struct {
-    OggVorbis_File ogg_vorbis_file;
-    int bitstream;
-
-    ogg_vorbis_streamfile ov_streamfile;
-    int disable_reordering; /* Xiph reorder channels on output, except for some devs */
-} ogg_vorbis_codec_data;
+typedef struct ogg_vorbis_codec_data ogg_vorbis_codec_data;
 
 
 /* custom Vorbis modes */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -828,6 +828,7 @@ typedef struct {
     size_t interleave_first_block_size; /* different interleave for first block */
     size_t interleave_first_skip;   /* data skipped before interleave first (needed to skip other channels) */
     size_t interleave_last_block_size; /* smaller interleave for last block */
+    size_t frame_size;              /* for codecs with configurable size */
 
     /* subsong config */
     int num_streams;                /* for multi-stream formats (0=not set/one stream, 1=one stream) */

--- a/winamp/Makefile
+++ b/winamp/Makefile
@@ -15,7 +15,7 @@ endif
 ### main defs
 OUTPUT_WINAMP = in_vgmstream.dll
 
-CFLAGS += -Wall -Werror=format-security -Wdeclaration-after-statement -Wvla -O3 -DUSE_ALLOCA -DWIN32 -I../ext_includes $(EXTRA_CFLAGS)
+CFLAGS += -ffast-math -O3 -Wall -Werror=format-security -Wdeclaration-after-statement -Wvla -DUSE_ALLOCA -DWIN32 -I../ext_includes $(EXTRA_CFLAGS)
 LDFLAGS += -L../src -L../ext_libs -lm -lvgmstream $(EXTRA_LDFLAGS)
 TARGET_EXT_LIBS = 
 

--- a/xmplay/Makefile
+++ b/xmplay/Makefile
@@ -15,7 +15,7 @@ endif
 ### main defs
 OUTPUT_XMPLAY = xmp-vgmstream.dll
 
-CFLAGS += -Wall -Werror=format-security -Wdeclaration-after-statement -Wvla -O3 -DUSE_ALLOCA -DWIN32 -I../ext_includes $(EXTRA_CFLAGS)
+CFLAGS += -ffast-math -O3 -Wall -Werror=format-security -Wdeclaration-after-statement -Wvla -DUSE_ALLOCA -DWIN32 -I../ext_includes $(EXTRA_CFLAGS)
 LDFLAGS += -L../src -L../ext_libs -lm -lvgmstream $(EXTRA_LDFLAGS)
 TARGET_EXT_LIBS = 
 


### PR DESCRIPTION
- Allow Ogg decoder to be used like other codecs
- Add SGXD with Ogg [Ni no Kuni Remastered (PC)]
- Add .spt+.spd subsongs
- Add streamfile helpers
- Clean RIFF Ogg code
- Add UE4OPUS v2 [Travis Strikes Again: No More Heroes (PC)]
- Add UE4 ADPCM v2 interleaved mono MSADPCM [Fortnite (PC)]
- Clean MSADPCM frame size and add extra check
- Add partial support for interleaved .XA/STR
- Add .bwav with PCM16 [Ring Fit Adventure (Switch)]
- Optimize float-to-int in ffmpeg
