### PR TITLE
Fix signedness bug in Game.com parsing

### DIFF
--- a/src/meta/tgc.c
+++ b/src/meta/tgc.c
@@ -14,7 +14,7 @@ VGMSTREAM * init_vgmstream_tgc(STREAMFILE *streamFile) {
     if (!vgmstream) goto fail;
 
     vgmstream->sample_rate = 8000;
-    vgmstream->num_samples = (read_16bitBE(1, streamFile) - 3) * 2;
+    vgmstream->num_samples = ((uint16_t)read_16bitBE(1, streamFile) - 3) * 2;
     vgmstream->meta_type   = meta_TGC;
     vgmstream->layout_type = layout_none;
     vgmstream->coding_type = coding_TGC;


### PR DESCRIPTION
vgmstream would fail parsing sounds > 32678.