### PR TITLE
documentation update.

### DIFF
--- a/src/meta/ngc_vid1.c
+++ b/src/meta/ngc_vid1.c
@@ -2,8 +2,7 @@
 #include "../util.h"
 #include "../coding/coding.h"
 
-
-/* VID1 - from Neversoft games (Gun, Tony Hawk's American Wasteland GC) */
+/* VID1 - DivX format designed specifically for GameCube and Xbox games (Gun [GC], Tony Hawk's American Wasteland [GC]) */
 VGMSTREAM * init_vgmstream_ngc_vid1(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     off_t start_offset, header_offset, header_size;


### PR DESCRIPTION
i'm contributing some new info to the "VID1" format that is already covered in vgmstream.
this "VID1" format has been designed by Factor 5 in partnership with DivX to "bring superior FMV quality" to both GameCube and Xbox consoles. that is to say, to take advantage of the hardware available in these consoles to play back several cutscenes in a game that were encoded with the DivX codec.

more (ancient) info here:
https://web.archive.org/web/20050810081822/http://www.divx.com/corporate/solutions/gaming/gamecube.php
https://web.archive.org/web/20050306212053/http://www.divxnetworks.com/solutions/gaming/xbox.php

i have some files that contain this "VID1" format, so i'll try to bring them up whenever i can.