### PR TITLE
txth

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -460,6 +460,7 @@ static const char* extension_list[] = {
     "spsd",
     "spw",
     "ss2",
+    "ssd", //txth/reserved [Zack & Wiki (Wii)]
     "ssm",
     "sss",
     "ster",


### PR DESCRIPTION
- Add .ssd extension [Zack & Wiki (Wii)]
- Fix TXTH base_offset chaining and other edge cases
  - allow name_table when setting body_file
  - match paths in name_table (needs wildcard: *path/file.ext)
  - always apply base_offset to coefs/hist/name_offset
