### PR TITLE
fix CLI build with autotools

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -29,7 +29,7 @@ sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $AUDACIOUS_HDRS/g" ./audacious/Makefile
 # again, not very pretty
 VGMSTREAM_VERSION=`./version.sh`
 sed -i -e "s/VGMSTREAM_VERSION/$VGMSTREAM_VERSION/g" ./audacious/Makefile.autotools.am
-
+sed -i -e "s/VGMSTREAM_VERSION/$VGMSTREAM_VERSION/g" ./cli/Makefile.autotools.am
 
 # create fake files expected by automake and process
 touch README AUTHORS NEWS ChangeLog

--- a/cli/Makefile.autotools.am
+++ b/cli/Makefile.autotools.am
@@ -6,7 +6,7 @@ if HAVE_LIBAO
 bin_PROGRAMS += vgmstream123
 endif
 
-AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ $(AO_CFLAGS)
+AM_CFLAGS = -DVERSION=\"VGMSTREAM_VERSION\" -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ $(AO_CFLAGS)
 AM_MAKEFLAGS = -f Makefile.autotools
 
 vgmstream_cli_SOURCES = vgmstream_cli.c


### PR DESCRIPTION
I'm not sure if this is still a supported way to build, but the [AUR package](https://aur.archlinux.org/packages/vgmstream-kode54-git/) still uses it.