### PR TITLE
txtp_maker: Update get_stream_mask to work with latest vgmstream

### DIFF
--- a/cli/txtp_maker.py
+++ b/cli/txtp_maker.py
@@ -330,12 +330,12 @@ class TxtpMaker(object):
     def get_stream_mask(self, layer):
         cfg = self.cfg
 
-        mask = '#c'
+        mask = '#C'
 
-        loops = cfg.layers
+        loops = cfg.layers + 1
         if layer + cfg.layers > self.channels:
             loops = self.channels - cfg.layers
-        for ch in range(0,loops):
+        for ch in range(1,loops):
             mask += str(layer+ch) + ','
 
         mask = mask[:-1]


### PR DESCRIPTION
- Use `#C` instead of `#c` (removes non-selected channels)
- Make it start the channel count from 1 instead of 0