### PR TITLE
Add hca key and rsp

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -395,6 +395,7 @@ static const char* extension_list[] = {
     "rsd",
     "rsf",
     "rsm",
+    "rsp",
     "rstm", //fake extension/header id for .rstm (in bigfiles)
     "rvws",
     "rwar",

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -345,6 +345,10 @@ static const hcakey_info hcakey_list[] = {
 
         /* Cardcaptor Sakura: Happiness Memories (Android) */
         {625144437747651},          // 00023890C8252FC3
+
+        /* Digimon Story: Cyber Sleuth (PC) */
+        {0x283553DCE3FD5FB9},       // 283553DCE3FD5FB9
+
 };
 
 #endif/*_HCA_KEYS_H_*/

--- a/src/meta/rsd.c
+++ b/src/meta/rsd.c
@@ -13,7 +13,7 @@ VGMSTREAM * init_vgmstream_rsd(STREAMFILE *streamFile) {
 
 
     /* checks */
-    if (!check_extensions(streamFile,"rsd"))
+    if (!check_extensions(streamFile,"rsd,rsp"))
         goto fail;
     if ((read_32bitBE(0x00,streamFile) & 0xFFFFFF00) != 0x52534400) /* "RSD\00" */
         goto fail;


### PR DESCRIPTION
-Add HCA key for Digimon Story: Cyber Sleuth (PC)
-Add RSP ext. for The Simpsons: Road Rage (PS2)