### PR TITLE
riff seek bank

### DIFF
--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -95,7 +95,19 @@ BIK_E1_6A_DialEnd_00000000.audio.multi.bik#3
 
 mode = layers
 ```
-Note that the number of channels is the sum of all layers so three 2ch layers play as a 6ch file (you can manually downmix using mixing commands, described later, since vgmstream can't guess if the result should be stereo or 5.1 audio). If all layers share loop points they are automatically kept.
+
+If all layers share loop points they are automatically kept.
+```
+BGM1a.adx  # loops from 10.0 to 90.0
+BGM1b.adx  # loops from 10.0 to 90.0
+mode = layers
+# resulting file loops from 10.0 to 90.0
+
+# if layers *don't* share loop points this sets a full loop (0..max)
+loop_mode = auto
+```
+
+Note that the number of channels is the sum of all layers so three 2ch layers play as a 6ch file (you can manually downmix using mixing commands, described later, since vgmstream can't guess if the result should be stereo or 5.1 audio).
 
 
 ### Mixed groups
@@ -158,7 +170,7 @@ Examples:
 - `S`: take all files as segments (equivalent to `mode = segments`)
 - `3L2`: layer 2 files starting from file 3
 - `2L3R`: group every 3 files from position 2 as layers
-- `1S1`: segment of one file (useless thus ignored)
+- `1S1`: segment of one file (mostly useless but allowed as internal file may have play config)
 - `1L1`: layer of one file (same)
 - `9999L`: absurd values are ignored
 

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -371,8 +371,8 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
     if (file_size != riff_size + 0x08) {
         uint16_t codec = read_16bitLE(0x14,sf);
 
-        if (riff_size + 0x08 + 0x01 == file_size)
-            riff_size += 0x01; /* [Shikkoku no Sharnoth (PC)] */
+        if      (codec == 0x6771 && riff_size + 0x08 + 0x01 == file_size)
+            riff_size += 0x01; /* [Shikkoku no Sharnoth (PC)] (Sony Sound Forge?) */
 
         else if (codec == 0x0069 && riff_size == file_size)
             riff_size -= 0x08; /* [Dynasty Warriors 3 (Xbox), BloodRayne (Xbox)] */
@@ -386,11 +386,14 @@ VGMSTREAM* init_vgmstream_riff(STREAMFILE* sf) {
         else if (codec == 0x0000 && riff_size == file_size)
             riff_size -= 0x08; /* [Rayman 2 (DC)] */
 
-        else if (codec == 0x0000 && riff_size + 0x02 + 0x08 == file_size)
+        else if (codec == 0x0000 && riff_size + 0x08 + 0x02 == file_size)
             riff_size -= 0x02; /* [Rayman 2 (DC)]-dcz */
 
         else if (codec == 0x0300 && riff_size == file_size)
             riff_size -= 0x08; /* [Chrono Ma:gia (Android)] */
+
+        else if (codec == 0xFFFE && riff_size + 0x08 + 0x18 == file_size)
+            riff_size += 0x18; /* [F1 2011 (Vita)] (adds a "pada" chunk but RIFF size wasn't updated) */
 
         else if (mwv) {
             int channels = read_16bitLE(0x16, sf); /* [Dragon Quest VIII (PS2), Rogue Galaxy (PS2)] */

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -373,7 +373,7 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE* sf) {
             else {
                 /* newer Wwise (>2012) */
                 off_t extra_offset = ww.fmt_offset + 0x18; /* after flag + channels */
-                int is_wem = check_extensions(sf,"wem");
+                int is_wem = check_extensions(sf,"wem,bnk"); /* use extension as a guide for faster vorbis inits */
 
                 switch(ww.extra_size) {
                     case 0x30:
@@ -382,7 +382,7 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE* sf) {
                         cfg.header_type = WWV_TYPE_2;
                         cfg.packet_type = WWV_MODIFIED;
 
-                        /* setup not detectable by header, so we'll try both; hopefully libvorbis will reject wrong codebooks
+                        /* setup not detectable by header, so we'll try both; libvorbis should reject wrong codebooks
                          * - standard: early (<2012), ex. The King of Fighters XIII (X360)-2011/11, .ogg (cbs are from aoTuV, too)
                          * - aoTuV603: later (>2012), ex. Sonic & All-Stars Racing Transformed (PC)-2012/11, .wem */
                         cfg.setup_type  = is_wem ? WWV_AOTUV603_CODEBOOKS : WWV_EXTERNAL_CODEBOOKS; /* aoTuV came along .wem */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -737,6 +737,8 @@ VGMSTREAM* allocate_vgmstream(int channel_count, int loop_flag) {
 
     mixing_init(vgmstream); /* pre-init */
 
+    /* BEWARE: try_dual_file_stereo does some free'ing too */ 
+
     //vgmstream->stream_name_size = STREAM_NAME_SIZE;
     return vgmstream;
 fail:
@@ -1203,6 +1205,7 @@ static void try_dual_file_stereo(VGMSTREAM* opened_vgmstream, STREAMFILE* sf, VG
 
         /* discard the second VGMSTREAM */
         mixing_close(new_vgmstream);
+        free(new_vgmstream->tmpbuf);
         free(new_vgmstream->start_vgmstream);
         free(new_vgmstream);
 


### PR DESCRIPTION
- Fix .AT9 with wrong padding [F1 2011 (Vita)]
- Fix seeking issues in winamp
- Fix memory leak with dual file stereo
- txtp: Allow single groups and loop_mode auto for layers
- Fix some .bank [Fall Guys (PC)]
